### PR TITLE
cmd line bug

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -918,7 +918,8 @@ def main():
         if options.atoms in ('all', 'hydrogen'):
             fixer.addMissingHydrogens(options.ph)
         if options.box is not None:
-            fixer.addSolvent(options.box*unit.nanometer, options.positiveIon, options.negativeIon, options.ionic*unit.molar)
+            fixer.addSolvent(boxSize=options.box*unit.nanometer, positiveIon=options.positiveIon, 
+                negativeIon=options.negativeIon, ionicStrength=options.ionic*unit.molar)
         app.PDBFile.writeFile(fixer.topology, fixer.positions, open(options.output, 'w'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
bugfix in cmd line interface where the args for addSolvent weren't being passed correctly

The padding arg was recently added to PDBFixer.addSolvent, but the command line interface had not been updated to reflect this. I changed the arguments to kwargs so that everything is passed correctly.
