### PR TITLE
Fixed incorrect call to addSolvent()

### DIFF
--- a/pdbfixer/ui.py
+++ b/pdbfixer/ui.py
@@ -80,7 +80,7 @@ def addHydrogensPageCallback(parameters, handler):
         ionicStrength = float(parameters.getfirst('ionicstrength'))*unit.molar
         positiveIon = parameters.getfirst('positiveion')+'+'
         negativeIon = parameters.getfirst('negativeion')+'-'
-        fixer.addSolvent(boxSize, positiveIon, negativeIon, ionicStrength)
+        fixer.addSolvent(boxSize, None, positiveIon, negativeIon, ionicStrength)
     displaySaveFilePage()
 
 def saveFilePageCallback(parameters, handler):


### PR DESCRIPTION
I was getting an error when adding the water box, due to an incorrect call to fixer.addSolvent().  The following simple fix takes care of the issue.
