### PR TITLE
Some bug fixes related to building missing residues

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -389,7 +389,7 @@ class PDBFixer(object):
 
                 # Create the new residue and add existing heavy atoms.
 
-                newResidue = newTopology.addResidue(residue.name, newChain, residue.id)
+                newResidue = newTopology.addResidue(residue.name, newChain, residue.id, residue.insertionCode)
                 for atom in residue.atoms():
                     if not heavyAtomsOnly or (atom.element is not None and atom.element != hydrogen):
                         if atom.name == 'OXT' and (chain.index, indexInChain+1) in self.missingResidues:


### PR DESCRIPTION
Some of my changes are related to [this](https://github.com/pandegroup/pdbfixer/issues/170) where I want to be able to specify the missing residues using `REMARK 465` sections. For now, I create `chainWithGapsOverride` in my own software (an old version is in issue #170) because it's quite complex and because I'm not sure if/how PDBFixer/OpenMM could/should extract and save the `REMARK 465` section from the original pdb.

I did make one change to `chainWithGaps` corresponding to the situation where there are waters following the sequence -- their presence was preventing the "alignment" step in `findMissingResidues` from working. I obviously don't have a list of all possible ligands and I don't want to examine CONECT records, but the approach of "known" residues seems ok to me.

This addresses an unreported issue of insertionCodes for not-missing residues are not preserved.

One problem I've not taken on is that `REMARK 465`'s specified resnum and insertion code are not necessarily preserved by `_addMissingResiduesToChain`. Seems minor and I don't have any tests cases for that right now.

This also addresses #175 
