### PR TITLE
Fix reading PDBx from filename

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -242,7 +242,7 @@ class PDBFixer(object):
             self.source = filename
             file = open(filename, 'r')
             if _guessFileFormat(file, filename) == 'pdbx':
-                self._initializeFromPDBx(file.read())
+                self._initializeFromPDBx(file)
             else:
                 self._initializeFromPDB(file)
             file.close()


### PR DESCRIPTION
Lines from the file where being passed to the reader rather than the file object - simple change from 
`self._initializeFromPDBx(file.read())` to `self._initializeFromPDBx(file)` fixes #202.