### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,15 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit codespell flake8
+      - run: bandit --recursive --skip B101,B310,B404,B602,B603 .
+      - run: codespell --ignore-words-list="noe,ser,villin"
+      - run: flake8 --ignore=E12,E22,E231,E261,E265,E30,E70,E711,E722,F401,F841,W29,W391,W504
+                    --max-complexity=25 --max-line-length=2624
+                    --show-source --statistics .

--- a/devtools/travis-ci/push-docs-to-s3.py
+++ b/devtools/travis-ci/push-docs-to-s3.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-Must have the vollowing environment variables defined:
+Must have the following environment variables defined:
 * BUCKET_NAME : AWS bucket name
 * PREFIX : 'latest' or other version number
 
@@ -21,7 +21,7 @@ else:
     PREFIX = thermopyl.version.short_version
 
 if not any(d.project_name == 's3cmd' for d in pip.get_installed_distributions()):
-    raise ImportError('The s3cmd pacakge is required. try $ pip install s3cmd')
+    raise ImportError('The s3cmd package is required. try $ pip install s3cmd')
 # The secret key is available as a secure environment variable
 # on travis-ci to push the build documentation to Amazon S3.
 with tempfile.NamedTemporaryFile('w') as f:

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -741,8 +741,8 @@ class PDBFixer(object):
         Notes
         -----
 
-        We require three letter codes to avoid possible ambiguitities.
-        We can't guarnatee that the resulting model is a good one; for
+        We require three letter codes to avoid possible ambiguities.
+        We can't guarantee that the resulting model is a good one; for
         significant changes in sequence, you should probably be using
         a standalone homology modelling tool.
 


### PR DESCRIPTION
[Travis CI](https://travis-ci.org/github/openmm/pdbfixer/builds) seems to be on (permanent?) vacation.

Results: https://github.com/cclauss/pdbfixer/actions