### PR TITLE
Fixed error leading to duplicate bonds

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -917,7 +917,7 @@ class PDBFixer(object):
             # Add the new bonds to the original Topology.
 
             inverseAtomMap = dict((y,x) for (x,y) in existingAtomMap.items())
-            for atom1, atom2 in newTopology.bonds():
+            for atom1, atom2 in newBonds:
                 self.topology.addBond(inverseAtomMap[atom1], inverseAtomMap[atom2])
         else:
 


### PR DESCRIPTION
This fixes an error that would sometime cause it to produce a PDB file with duplicate CONECT records for nonstandard residues.  However, it only happened if no heavy atoms were being added.  If it needed to add even a single heavy atom anywhere it the system, it followed a different code path and the error didn't happen.