### PR TITLE
fix CI badge; remove some old simtk

### DIFF
--- a/Manual.html
+++ b/Manual.html
@@ -230,7 +230,7 @@ If you want to add a lipid membrane, call <tt>addMembrane()</tt>.  This method a
 Here is a complete example that ties this together.  It adds all missing atoms including heavy atoms, missing residues, and hydrogens.  It replaces all nonstandard residues by their standard equivalents then deletes all remaining heterogens except water.  Finally, it fills in all gaps with water; that is, it adds a water box whose dimensions match the crystallographic unit cell.  It saves the result to a file called output.pdb.
 <tt><pre>
 from pdbfixer import PDBFixer
-from simtk.openmm.app import PDBFile
+from openmm.app import PDBFile
 fixer = PDBFixer(filename='myfile.pdb')
 fixer.findMissingResidues()
 fixer.findNonstandardResidues()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/pandegroup/pdbfixer.svg?branch=master)](https://travis-ci.org/pandegroup/pdbfixer)
+[![PDBFixer Continuous Integration Workflow](https://github.com/openmm/pdbfixer/actions/workflows/CI.yml/badge.svg)](https://github.com/openmm/pdbfixer/actions/workflows/CI.yml)
 
 PDBFixer
 ========

--- a/devtools/createSoftForcefield.py
+++ b/devtools/createSoftForcefield.py
@@ -33,9 +33,9 @@ from __future__ import print_function
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
-import simtk.openmm.app as app
-import simtk.openmm.app.element as elem
-import simtk.openmm.app.forcefield as ff
+import openmm.app as app
+import openmm.app.element as elem
+import openmm.app.forcefield as ff
 
 forcefield = app.ForceField('amber99sbildn.xml', 'tip3p.xml')
 bondK = 10000.0
@@ -143,7 +143,7 @@ print(' </PeriodicTorsionForce>')
 # Print the script to add the soft-core nonbonded force.
 
 print(' <Script>')
-print("""import simtk.openmm as mm
+print("""import openmm as mm
 nb = mm.CustomNonbondedForce('C/((r/0.2)^4+1)')
 nb.addGlobalParameter('C', 1.0)
 sys.addForce(nb)

--- a/pdbfixer/tests/test_build_and_simulate.py
+++ b/pdbfixer/tests/test_build_and_simulate.py
@@ -113,7 +113,7 @@ def test_build_and_simulate():
 
         # PDB setup parameters.
         # TODO: Try several combinations?
-        from simtk import unit
+        from openmm import unit
         pH = 7.0
         ionic = 50.0 * unit.millimolar
         box = 10.0 * unit.angstrom
@@ -128,7 +128,7 @@ def test_build_and_simulate():
         build_successful = False
         try:        
             from pdbfixer.pdbfixer import PDBFixer
-            from simtk.openmm import app
+            from openmm import app
             stage = "Creating PDBFixer..."
             fixer = PDBFixer(pdbid=pdbcode)
             stage = "Finding missing residues..."


### PR DESCRIPTION
The README badge didn't get updated after the switch to GitHub actions in #225. Fixes that. Also, I caught a couple places that still had `simtk` imports.