### PR TITLE
[bug] Ensure numpy < 2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ setup(
     packages=find_packages(),
     package_data={'pdbfixer': find_package_data()},
     zip_safe=False,
-    install_requires=['numpy', 'openmm >= 7.1'],
+    install_requires=['numpy < 2', 'openmm >= 7.1'],
     entry_points={'console_scripts': ['pdbfixer = pdbfixer.pdbfixer:main']})
 


### PR DESCRIPTION
TL;DR Small bug fix for `numpy < 2` version cap.

I encountered an error when attempting to perform a local installation of `pdbfixer` on macOS Sonoma 14.1, Apple M3 Max with python 3.12.3.

After creating a clean virtual environment and `pip install setuptools`, I ran `python setup.py install`. The installation appears to successfully complete, however when calling the CLI executable `pdbfixer`, the following (abbreviated) error message is displayed:

```
...
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0rc2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
...
```

This error is preventing successful execution of `pdbfixer`.

Looking at `setup.py`, I see that the version for `numpy` is not specified, in which case I believe the installation will attempt to use the latest available version. According to the [release history](https://pypi.org/project/numpy/1.20.3/#history) of `numpy`, the latest version is now `numpy 2.0.0rc2`. I believe this was the root cause of the error.

To help, I simply added a version cap in `setup.py` for `numpy < 2`. Then, re-installing succeeds, and the CLI `pdbfixer` command works as expected.