### PR TITLE
Bugfixed chain ID assignment in addSolvent (#287)

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1094,12 +1094,28 @@ class PDBFixer(object):
 
         modeller = app.Modeller(self.topology, self.positions)
         forcefield = self._createForceField(self.topology, True)
+        original_chains = list(modeller.topology.chains())
         modeller.addSolvent(forcefield, padding=padding, boxSize=boxSize, boxVectors=boxVectors, boxShape=boxShape, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength)
-        chains = list(modeller.topology.chains())
-        if len(chains) == 1:
-            chains[0].id = 'A'
-        else:
-            chains[-1].id = chr(ord(chains[-2].id)+1)
+        new_chains = list(modeller.topology.chains())
+        added_chain_indices = range(len(original_chains), len(new_chains))
+        assert 1 <= len(added_chain_indices) <= 2, "Expected a new solvent chain and optionally a new ion chain"
+
+        for added_chain_index in added_chain_indices:
+            added_chain = new_chains[added_chain_index]
+            assert added_chain.id.isnumeric(), "Expected numeric chain ID assigned by modeller.addSolvent"
+
+            # If the last chain ID is a letter between A and Y, assign the next letter for the added chain ID.
+            if added_chain_index > 0:
+                prev_chain_id = new_chains[added_chain_index - 1].id
+                if len(prev_chain_id) == 1 and prev_chain_id.isalpha():
+                    abet_index = ord(prev_chain_id.upper()) - ord("A") + 1
+                    if abet_index < 26:
+                        # A-Z
+                        added_chain.id = chr(ord("A") + abet_index)
+                    else:
+                        # Otherwise, leave the ID as a string representing its index.
+                        pass
+
         self.topology = modeller.topology
         self.positions = modeller.positions
 

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -534,6 +534,25 @@ class PDBFixer(object):
                 templatePosition = template.positions[atom.index].value_in_unit(unit.nanometer)
                 newPositions.append(mm.Vec3(*np.dot(rotate, templatePosition))*unit.nanometer+translate)
 
+    def _renameNewChains(self, startIndex):
+        """Rename newly added chains to conform with existing naming conventions.
+        
+        Parameters
+        ----------
+        startIndex : int
+            The index of the first new chain in self.topology.chains().
+        """
+        # If all chains are new, nothing to do
+        if startIndex == 0:
+            return
+
+        # If the last chain ID was originally a letter, continue alphabetically until reaching Z
+        chains = list(self.topology.chains())
+        for newChainIndex in range(startIndex, len(chains)):
+            prevChainId = chains[newChainIndex - 1].id
+            if len(prevChainId) == 1 and "A" <= prevChainId < "Z":
+                chains[newChainIndex].id = chr(ord(prevChainId) + 1)
+
     def removeChains(self, chainIndices=None, chainIds=None):
         """Remove a set of chains from the structure.
 
@@ -1092,21 +1111,13 @@ class PDBFixer(object):
 
         """
 
+        nChains = sum(1 for _ in self.topology.chains())
         modeller = app.Modeller(self.topology, self.positions)
         forcefield = self._createForceField(self.topology, True)
-        old_chains = list(modeller.topology.chains())
         modeller.addSolvent(forcefield, padding=padding, boxSize=boxSize, boxVectors=boxVectors, boxShape=boxShape, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength)
-        new_chains = list(modeller.topology.chains())
-
-        # If the last chain ID is alphabetic, continue alphabetically until reaching Z
-        if len(old_chains) > 0:
-            for added_chain_index in range(len(old_chains), len(new_chains)):
-                prev_chain_id = new_chains[added_chain_index - 1].id
-                if len(prev_chain_id) == 1 and "A" <= prev_chain_id < "Z":
-                    new_chains[added_chain_index].id = chr(ord(prev_chain_id) + 1)
-
         self.topology = modeller.topology
         self.positions = modeller.positions
+        self._renameNewChains(nChains)
 
     def addMembrane(self, lipidType='POPC', membraneCenterZ=0*unit.nanometer, minimumPadding=1*unit.nanometer, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*unit.molar):
         """Add a lipid membrane to the structure.
@@ -1129,16 +1140,14 @@ class PDBFixer(object):
         ionicStrength : openmm.unit.Quantity with units compatible with molar, optional, default=0*molar
             The total concentration of ions (both positive and negative) to add.  This does not include ions that are added to neutralize the system.
         """
+
+        nChains = sum(1 for _ in self.topology.chains())
         modeller = app.Modeller(self.topology, self.positions)
         forcefield = self._createForceField(self.topology, True)
         modeller.addMembrane(forcefield, lipidType=lipidType, minimumPadding=minimumPadding, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength)
-        chains = list(modeller.topology.chains())
-        if len(chains) == 1:
-            chains[0].id = 'A'
-        else:
-            chains[-1].id = chr(ord(chains[-2].id)+1)
         self.topology = modeller.topology
         self.positions = modeller.positions
+        self._renameNewChains(nChains)
 
     def _createForceField(self, newTopology, water):
         """Create a force field to use for optimizing the positions of newly added atoms."""


### PR DESCRIPTION
How does this approach work for fixing #287?  This should assign B-Z if the previous chain ID was A-Y, and otherwise leave the ID as a numeric chain ID.

One comment:  I noticed PDBFile and PDBxFile simply use `% 26` to map numeric IDs to the alphabet.  Should we warn the user somehow that disparate chains may be assigned matching IDs in these cases?