### PR TITLE
Neutralise systems with formal charges from the PDB

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -467,7 +467,7 @@ class PDBFixer(object):
             return self.templates[name]
         return None
 
-    def registerTemplate(self, topology, positions, terminal=None, formalCharges=None):
+    def registerTemplate(self, topology, positions, terminal=None):
         """Register a template for a nonstandard residue.  This allows PDBFixer to add missing residues of this type,
         to add missing atoms to existing residues, and to mutate other residues to it.
         Parameters

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1436,6 +1436,7 @@ class PDBFixer(object):
 
         """
 
+        self.downloadCharges()
         nChains = sum(1 for _ in self.topology.chains())
         modeller = app.Modeller(self.topology, self.positions)
         forcefield = self._createForceField(self.topology, True)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1512,10 +1512,11 @@ class PDBFixer(object):
             indexInResidue = {}
             for atom in residue.atoms():
                 element = atom.element
-                typeName = 'extra_'+element.symbol
-                if element not in atomTypes:
-                    atomTypes[element] = app.ForceField._AtomType(typeName, '', 0.0, element)
-                    forcefield._atomTypes[typeName] = atomTypes[element]
+                formalCharge = self._getFormalCharge(atom.index, 0)
+                typeName = 'extra_'+element.symbol+'_'+str(formalCharge)
+                if (element, formalCharge) not in atomTypes:
+                    atomTypes[(element, formalCharge)] = app.ForceField._AtomType(typeName, '', 0.0, element)
+                    forcefield._atomTypes[typeName] = atomTypes[(element, formalCharge)]
                     if water:
                         # Select a reasonable vdW radius for this atom type.
 
@@ -1523,7 +1524,12 @@ class PDBFixer(object):
                             sigma = radii[element.symbol]
                         else:
                             sigma = 0.5
-                        nonbonded.registerAtom({'type':typeName, 'charge':'0', 'sigma':str(sigma), 'epsilon':'0'})
+                        nonbonded.registerAtom({
+                            'type':typeName,
+                            'charge':str(formalCharge),
+                            'sigma':str(sigma),
+                            'epsilon':'0'
+                        })
                 indexInResidue[atom.index] = len(template.atoms)
                 template.atoms.append(app.ForceField._TemplateAtomData(atom.name, typeName, element))
             for atom in residue.atoms():

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -138,6 +138,7 @@ class CCDResidueDefinition:
         reader.read(data)
         block = data[0]
 
+        # TODO: Fix
         residueName = block.getObj('chem_comp.id')
 
         atomData = block.getObj('chem_comp_atom')
@@ -155,7 +156,7 @@ class CCDResidueDefinition:
                 atomName=row[atomNameCol],
                 symbol=row[symbolCol],
                 leaving=row[leavingCol] == 'Y',
-                coords=mm.vec3(float(row[xCol]), float(row[yCol]), float(row[zCol]))*0.1,
+                coords=mm.Vec3(float(row[xCol]), float(row[yCol]), float(row[zCol]))*0.1,
                 charge=row[chargeCol],
                 aromatic=row[aromaticCol] == 'Y'
             ) for row in atomData.getRowList()
@@ -173,7 +174,7 @@ class CCDResidueDefinition:
                     atom2=row[atom2Col],
                     order=row[orderCol],
                     aromatic=row[aromaticCol] == 'Y',
-                ) for row in atomData.getRowList()
+                ) for row in bondData.getRowList()
             ]
         else:
             bonds = []
@@ -1493,7 +1494,7 @@ class PDBFixer(object):
             return {}
 
         # Record the formal charges.
-        return {atom.atomName: atom.charge for atom in ccdDefinition}
+        return {atom.atomName: atom.charge for atom in ccdDefinition.atoms}
 
     def _createForceField(self, newTopology, water):
         """Create a force field to use for optimizing the positions of newly added atoms."""

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1432,7 +1432,7 @@ class PDBFixer(object):
             variant.append((h, parent))
         return variant
 
-    def addSolvent(self, boxSize=None, padding=None, boxVectors=None, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*unit.molar, boxShape='cube'):
+    def addSolvent(self, boxSize=None, padding=None, boxVectors=None, positiveIon='Na+', negativeIon='Cl-', ionicStrength=0*unit.molar, boxShape='cube', forceField=None):
         """Add a solvent box surrounding the structure.
 
         Parameters
@@ -1449,8 +1449,13 @@ class PDBFixer(object):
             The type of negative ion to add.  Allowed values are 'Cl-', 'Br-', 'F-', and 'I-'.
         ionicStrength : openmm.unit.Quantity with units compatible with molar, optional, default=0*molar
             The total concentration of ions (both positive and negative) to add.  This does not include ions that are added to neutralize the system.
-        boxShape: str='cube'
-            the box shape to use.  Allowed values are 'cube', 'dodecahedron', and 'octahedron'.  If padding is None, this is ignored.
+        boxShape : str='cube'
+            The box shape to use.  Allowed values are 'cube', 'dodecahedron', and 'octahedron'.  If padding is None, this is ignored.
+        forceField : openmm.app.ForceField, optional
+            The force field to use for determining van der Waals radii and
+            atomic charges. If not set, a force field will be generated. If the
+            solvated topology has a nonzero total charge, provide a force field
+            that correctly charges the solute.
 
         Examples
         --------
@@ -1468,8 +1473,9 @@ class PDBFixer(object):
 
         nChains = sum(1 for _ in self.topology.chains())
         modeller = app.Modeller(self.topology, self.positions)
-        forcefield = self._createForceField(self.topology, True)
-        modeller.addSolvent(forcefield, padding=padding, boxSize=boxSize, boxVectors=boxVectors, boxShape=boxShape, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength)
+        if forceField is None:
+            forceField = self._createForceField(self.topology, True)
+        modeller.addSolvent(forceField, padding=padding, boxSize=boxSize, boxVectors=boxVectors, boxShape=boxShape, positiveIon=positiveIon, negativeIon=negativeIon, ionicStrength=ionicStrength)
         self.topology = modeller.topology
         self.positions = modeller.positions
         self._renameNewChains(nChains)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -490,12 +490,12 @@ class PDBFixer(object):
             if template is None or template.formalCharges is None:
                 continue
             formalChargesByAtomName = {
-                atom.name: formalCharge
+                atom.name.upper(): formalCharge
                 for atom, formalCharge in zip(template.topology.atoms(), template.formalCharges)
             }
             for atom in residue.atoms():
                 try:
-                    formalCharge = formalChargesByAtomName[atom.name]
+                    formalCharge = formalChargesByAtomName[atom.name.upper()]
                 except IndexError:
                     raise ValueError(
                         f"Atom {atom.name} in residue {residue.name}#{residue.id} is missing from"

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -101,13 +101,12 @@ class ModifiedResidue(object):
 
 class Template:
     """Template represents a standard residue, or a nonstandard one registered with registerTemplate()."""
-    def __init__(self, topology, positions, terminal=None, formalCharges=None):
+    def __init__(self, topology, positions, terminal=None):
         self.topology = topology
         self.positions = positions
         if terminal is None:
             terminal = [False]*topology.getNumAtoms()
         self.terminal = terminal
-        self.formalCharges = formalCharges
 
 def _guessFileFormat(file, filename):
     """Guess whether a file is PDB or PDBx/mmCIF based on its filename and contents."""
@@ -280,9 +279,6 @@ class PDBFixer(object):
         if len(atoms) == 0:
             raise Exception("Structure contains no atoms.")
 
-        # Initialise the list of formal charges
-        self.formalCharges = [None] * len(atoms)
-
         # Load the templates.
 
         self.templates = {}
@@ -358,11 +354,9 @@ class PDBFixer(object):
                 for row in modData.getRowList():
                     self.modifiedResidues.append(ModifiedResidue(row[asymIdCol], int(row[resNumCol]), row[resNameCol], row[standardResCol]))
 
-    def _getTemplate(self, name, downloadIfMissing=False):
+    def _getTemplate(self, name):
         """Return the template with a name.  If none has been registered, this will return None."""
         if name in self.templates:
-            return self.templates[name]
-        if downloadIfMissing and self.downloadTemplate(name):
             return self.templates[name]
         return None
 
@@ -381,9 +375,6 @@ class PDBFixer(object):
             If this is present, it should be a list of length equal to the number of atoms in the residue.
             If an element is True, that indicates the corresponding atom should only be added to terminal
             residues.
-        formalCharges: optional list of int
-            If this is present, it should be a list of length equal to the number of atoms in the residue.
-            Each element indicates the formal charge of the corresponding atom.
         """
         residues = list(topology.residues())
         if len(residues) != 1:
@@ -392,9 +383,7 @@ class PDBFixer(object):
             raise ValueError('The number of positions does not match the number of atoms in the Topology')
         if terminal is not None and len(terminal) != topology.getNumAtoms():
             raise ValueError('The number of terminal flags does not match the number of atoms in the Topology')
-        if formalCharges is not None and len(formalCharges) != topology.getNumAtoms():
-            raise ValueError('The number of formal charges does not match the number of atoms in the Topology')
-        self.templates[residues[0].name] = Template(topology, positions, terminal, formalCharges)
+        self.templates[residues[0].name] = Template(topology, positions, terminal)
 
     def downloadTemplate(self, name):
         """Attempt to download a residue definition from the PDB and register a template for it.
@@ -431,21 +420,18 @@ class PDBFixer(object):
         yCol = atomData.getAttributeIndex('pdbx_model_Cartn_y_ideal')
         zCol = atomData.getAttributeIndex('pdbx_model_Cartn_z_ideal')
         zCol = atomData.getAttributeIndex('pdbx_model_Cartn_z_ideal')
-        formalChargeCol = atomData.getAttributeIndex('charge')
         topology = app.Topology()
         chain = topology.addChain()
         residue = topology.addResidue(name, chain)
         positions = []
         atomByName = {}
         terminal = []
-        formalCharges = []
         for row in atomData.getRowList():
             atomName = row[atomNameCol]
             atom = topology.addAtom(atomName, app.Element.getBySymbol(row[symbolCol]), residue)
             atomByName[atomName] = atom
             terminal.append(row[leavingCol] == 'Y')
             positions.append(mm.Vec3(float(row[xCol]), float(row[yCol]), float(row[zCol]))*0.1)
-            formalCharges.append(row[formalChargeCol])
         positions = positions*unit.nanometers
 
         # Load the bonds.
@@ -456,54 +442,49 @@ class PDBFixer(object):
             atom2Col = bondData.getAttributeIndex('atom_id_2')
             for row in bondData.getRowList():
                 topology.addBond(atomByName[row[atom1Col]], atomByName[row[atom2Col]])
-        self.registerTemplate(topology, positions, terminal, formalCharges)
+        self.registerTemplate(topology, positions, terminal)
         return True
 
-    def _getFormalCharge(self, index, default=None):
-        if index < len(self.formalCharges):
-            formalCharge = self.formalCharges[index]
-            return default if formalCharge is None else formalCharge
-        return default
-
-    def downloadCharges(self, skipResidueNames=[]):
+    def getAllFormalCharges(self, skipResidueNames=[]):
         """
-        Download and assign formal charges for nonstandard residues from the CCD.
+        Download formal charges from the CCD for atoms from nonstandard residues.
 
-        Formal charges are used to neutralise systems during solvation. Residues whose templates are
-        included in PDBFixer (canonical amino acids, caps, nucleotides, and ribonucleotides) are not
-        assigned charges as they may be titrated away from their canonical protonation states, and
-        these formal charges are computed separately during solvation.
+        Returns a list of the formal charges of all atoms in the topology. Atoms
+        whose formal charge could not be assigned are given a charge of ``None``.
 
         Parameters
         ----------
         skipResidueNames : list of strings
-            A list of residue names to skip when assigning formal charges. Any residues not included
-            in this list will cause the entire method to fail if they attempt to assign a charge to
-            an atom that is missing from the corresponding template.
+            A list of residue names to skip when assigning formal charges. Any
+            residues not included in this list will cause the entire method to
+            fail if they attempt to assign a charge to an atom that is missing
+            from the corresponding template.
         """
-        formalCharges = list(self.formalCharges[:self.topology.getNumAtoms()])
-        formalCharges += [None] * (self.topology.getNumAtoms() - len(formalCharges))
+        formalCharges = [None] * (self.topology.getNumAtoms())
+
+        formalChargesByResidue = {}
+
         for residue in self.topology.residues():
             if residue.name in skipResidueNames:
                 continue
-            template = self._getTemplate(residue.name, downloadIfMissing=True)
-            if template is None or template.formalCharges is None:
-                continue
-            formalChargesByAtomName = {
-                atom.name.upper(): formalCharge
-                for atom, formalCharge in zip(template.topology.atoms(), template.formalCharges)
-            }
+
+            formalChargesByAtomName = formalChargesByResidue.setdefault(residue.name, {})
+
+            if not formalChargesByAtomName:
+                formalChargesByAtomName.update(self._downloadFormalCharges(residue.name))
+
             for atom in residue.atoms():
                 try:
                     formalCharge = formalChargesByAtomName[atom.name.upper()]
                 except IndexError:
                     raise ValueError(
                         f"Atom {atom.name} in residue {residue.name}#{residue.id} is missing from"
-                        + f" the template. To assign formal charges to other residues, include"
-                        + f" {residue.name} in the list passed to the skipResidueNames argument."
+                        + f" the CCD, so formal charges cannot be assigned. To assign formal"
+                        + f" charges to other residues, include {residue.name} in the list passed"
+                        + f" to the skipResidueNames argument."
                     )
                 formalCharges[atom.index] = formalCharge
-        self.formalCharges = formalCharges
+        return formalCharges
 
 
     def _addAtomsToTopology(self, heavyAtomsOnly, omitUnknownMolecules):
@@ -1436,7 +1417,6 @@ class PDBFixer(object):
 
         """
 
-        self.downloadCharges()
         nChains = sum(1 for _ in self.topology.chains())
         modeller = app.Modeller(self.topology, self.positions)
         forcefield = self._createForceField(self.topology, True)
@@ -1475,6 +1455,40 @@ class PDBFixer(object):
         self.positions = modeller.positions
         self._renameNewChains(nChains)
 
+    def _downloadFormalCharges(self, resName):
+        """
+        Download the formal charges for a residue name from the CCD
+
+        Returns
+        -------
+        formalCharges
+            Dictionary mapping from atom names (``str``) to formal charges (``int``)
+        """
+        # Try to download the definition.
+
+        try:
+            file = urlopen(f'https://files.rcsb.org/ligands/download/{resName}.cif')
+            contents = file.read().decode('utf-8')
+            file.close()
+        except:
+            return {}
+
+        # Record the formal charges.
+
+        from openmm.app.internal.pdbx.reader.PdbxReader import PdbxReader
+        reader = PdbxReader(StringIO(contents))
+        data = []
+        reader.read(data)
+        block = data[0]
+        atomData = block.getObj('chem_comp_atom')
+        atomNameCol = atomData.getAttributeIndex('atom_id')
+        formalChargeCol = atomData.getAttributeIndex('charge')
+        formalCharges = {}
+        for row in atomData.getRowList():
+            atomName = row[atomNameCol]
+            formalCharges[atomName] = row[formalChargeCol]
+        return formalCharges
+
     def _createForceField(self, newTopology, water):
         """Create a force field to use for optimizing the positions of newly added atoms."""
 
@@ -1511,9 +1525,10 @@ class PDBFixer(object):
             template = app.ForceField._TemplateData(resName)
             forcefield._templates[resName] = template
             indexInResidue = {}
+            formalCharges = self._downloadFormalCharges(residue.name)
             for atom in residue.atoms():
                 element = atom.element
-                formalCharge = self._getFormalCharge(atom.index, 0)
+                formalCharge = formalCharges.get(atom.name, 0)
                 typeName = 'extra_'+element.symbol+'_'+str(formalCharge)
                 if (element, formalCharge) not in atomTypes:
                     atomTypes[(element, formalCharge)] = app.ForceField._AtomType(typeName, '', 0.0, element)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -743,7 +743,7 @@ class PDBFixer(object):
 
     def _renameNewChains(self, startIndex):
         """Rename newly added chains to conform with existing naming conventions.
-        
+
         Parameters
         ----------
         startIndex : int
@@ -1533,7 +1533,10 @@ class PDBFixer(object):
             template = app.ForceField._TemplateData(resName)
             forcefield._templates[resName] = template
             indexInResidue = {}
-            formalCharges = self.downloadFormalCharges(residue.name)
+            if water:
+                formalCharges = self.downloadFormalCharges(residue.name)
+            else:
+                formalCharges = defaultdict(lambda: 0)
             for atom in residue.atoms():
                 element = atom.element
                 formalCharge = formalCharges.get(atom.name, 0)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -138,7 +138,6 @@ class CCDResidueDefinition:
     Description of a residue from the Chemical Component Dictionary (CCD).
     """
     residueName: str
-    smiles: Optional[str]
     atoms: list[CCDAtomDefinition]
     bonds: list[CCDBondDefinition]
 
@@ -155,12 +154,6 @@ class CCDResidueDefinition:
 
         descriptorsData = block.getObj("pdbx_chem_comp_descriptor")
         typeCol = descriptorsData.getAttributeIndex("type")
-        smilesCol = descriptorsData.getAttributeIndex("descriptor")
-        smiles = None
-        for row in descriptorsData.getRowList():
-            if row[typeCol] in ["SMILES", "SMILES_CANONICAL"]:
-                smiles = row[smilesCol]
-                break
 
         atomData = block.getObj('chem_comp_atom')
         atomNameCol = atomData.getAttributeIndex('atom_id')
@@ -200,7 +193,7 @@ class CCDResidueDefinition:
         else:
             bonds = []
 
-        return cls(residueName=residueName, smiles=smiles, atoms=atoms, bonds=bonds)
+        return cls(residueName=residueName, atoms=atoms, bonds=bonds)
 
 def _guessFileFormat(file, filename):
     """Guess whether a file is PDB or PDBx/mmCIF based on its filename and contents."""
@@ -452,7 +445,7 @@ class PDBFixer(object):
                     self.modifiedResidues.append(ModifiedResidue(row[asymIdCol], int(row[resNumCol]), row[resNameCol], row[standardResCol]))
 
 
-    def _downloadCCDDefinition(self, residueName: str, checkCache: bool = True) -> Optional[CCDResidueDefinition]:
+    def _downloadCCDDefinition(self, residueName: str) -> Optional[CCDResidueDefinition]:
         """
         Download a residue definition from the Chemical Component Dictionary.
 
@@ -463,9 +456,6 @@ class PDBFixer(object):
         residueName : str
             The name of the residue, as specified in the PDB Chemical Component
             Dictionary.
-        checkCache : bool
-            If ``False``, attempt to re-download the CCD entry regardless of
-            what is in the cache. Defaults to ``True``.
 
         Returns
         -------
@@ -1572,7 +1562,7 @@ class PDBFixer(object):
             forcefield._templates[resName] = template
             indexInResidue = {}
             # If we can't find formal charges in the CCD, make everything uncharged
-            formalCharges = defaultdict(lambda: 0)
+            formalCharges = defaultdict(int)
             # See if we can get formal charges from the CCD
             if water:
                 # The formal charges in the CCD can only be relied on if the

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -466,7 +466,7 @@ class PDBFixer(object):
         """
         residueName = residueName.upper()
 
-        if checkCache and residueName in self._ccdCache:
+        if residueName in self._ccdCache:
             return self._ccdCache[residueName]
 
         try:

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1361,7 +1361,7 @@ class PDBFixer(object):
                 # Try to download the definition.
                 ccdDefinition = self._downloadCCDDefinition(name)
                 if ccdDefinition is None:
-                    return None
+                    continue
 
                 # Record the atoms and bonds.
                 atoms = [(atom.atomName, atom.symbol.upper(), atom.leaving) for atom in ccdDefinition.atoms]

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -453,6 +453,7 @@ class PDBFixer(object):
             contents = file.read().decode('utf-8')
             file.close()
         except:
+            self._ccdCache[name] = False
             return False
 
         reader = PdbxReader(StringIO(contents))

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -46,7 +46,6 @@ def test_charge_and_solvate(pdbCode, soluteCharge):
     fixer.addMissingAtoms()
 
     fixer.addMissingHydrogens(pH=7.4)
-    fixer.downloadCharges()
     fixer.addSolvent(
         padding=2.0 * openmm.unit.nanometer,
         ionicStrength=0.1 * openmm.unit.molar,

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -32,9 +32,9 @@ def test_charge_and_solvate(pdbCode, soluteCharge):
     chainLengths = [len([*chain.residues()]) for chain in fixer.topology.chains()]
     for chainidx, residx in list(fixer.missingResidues):
         if residx == 0:
-            fixer.missingResidues[chainidx, residx] = ["ACE"]
+            fixer.missingResidues[chainidx, residx] = []
         elif residx == chainLengths[chainidx]:
-            fixer.missingResidues[chainidx, residx] = ["NME"]
+            fixer.missingResidues[chainidx, residx] = []
 
     fixer.findNonstandardResidues()
     fixer.replaceNonstandardResidues()

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -11,6 +11,7 @@ import openmm.unit
         ("110D", -5),
         ("1CNR", 0),
         ("1ESD", -21),
+        ("25c8", -2),
     ],
 )
 def test_charge_and_solvate(pdbCode, soluteCharge):

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -32,16 +32,18 @@ def test_charge_and_solvate(pdbCode, soluteCharge):
     chainLengths = [len([*chain.residues()]) for chain in fixer.topology.chains()]
     for chainidx, residx in list(fixer.missingResidues):
         if residx == 0:
-            fixer.missingResidues[chainidx, residx] = []
+            fixer.missingResidues[chainidx, residx] = ["GLY"]
+            # fixer.missingResidues[chainidx, residx] = []
+            # fixer.missingResidues[chainidx, residx] = ["ACE"]
         elif residx == chainLengths[chainidx]:
-            fixer.missingResidues[chainidx, residx] = []
+            fixer.missingResidues[chainidx, residx] = ["GLY"]
+            # fixer.missingResidues[chainidx, residx] = []
+            # fixer.missingResidues[chainidx, residx] = ["NME"]
 
-    fixer.findNonstandardResidues()
-    fixer.replaceNonstandardResidues()
     fixer.findMissingAtoms()
     fixer.addMissingAtoms()
-
     fixer.addMissingHydrogens(pH=7.4)
+
     fixer.addSolvent(
         padding=2.0 * openmm.unit.nanometer,
         ionicStrength=0.1 * openmm.unit.molar,

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -15,7 +15,7 @@ import openmm.unit
 )
 def test_charge_and_solvate(pdbCode, soluteCharge):
     """
-    Test that downloadCharges and addSolvent successfully neutralise the system
+    Test that addSolvent successfully neutralises systems
 
     Parameters
     ----------

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -29,16 +29,12 @@ def test_charge_and_solvate(pdbCode, soluteCharge):
     fixer = PDBFixer(pdbid=pdbCode)
     fixer.findMissingResidues()
 
-    chains_to_cap = {chain for chain, resi in fixer.missingResidues}
-    for chainidx in chains_to_cap:
-        chain = [*fixer.topology.chains()][chainidx]
-        last_resi = len([*chain.residues()])
-        # Capping with GLY because ACE/NME currently breaks addMissingHydrogens
-        # Adding a cap keeps the protein compact and the addSolvent call quick
-        fixer.missingResidues[chainidx, 0] = ["GLY"]
-        fixer.missingResidues[chainidx, last_resi] = ["GLY"]
-        # fixer.missingResidues[chainidx, 0] = ['ACE']
-        # fixer.missingResidues[chainidx, last_resi] = ['NME']
+    chainLengths = [len([*chain.residues()]) for chain in fixer.topology.chains()]
+    for chainidx, residx in list(fixer.missingResidues):
+        if residx == 0:
+            fixer.missingResidues[chainidx, residx] = ["ACE"]
+        elif residx == chainLengths[chainidx]:
+            fixer.missingResidues[chainidx, residx] = ["NME"]
 
     fixer.findNonstandardResidues()
     fixer.replaceNonstandardResidues()

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -34,12 +34,8 @@ def test_charge_and_solvate(pdbCode, soluteCharge):
     for chainidx, residx in list(fixer.missingResidues):
         if residx == 0:
             fixer.missingResidues[chainidx, residx] = ["GLY"]
-            # fixer.missingResidues[chainidx, residx] = []
-            # fixer.missingResidues[chainidx, residx] = ["ACE"]
         elif residx == chainLengths[chainidx]:
             fixer.missingResidues[chainidx, residx] = ["GLY"]
-            # fixer.missingResidues[chainidx, residx] = []
-            # fixer.missingResidues[chainidx, residx] = ["NME"]
 
     fixer.findMissingAtoms()
     fixer.addMissingAtoms()

--- a/pdbfixer/tests/test_charge_and_solvate.py
+++ b/pdbfixer/tests/test_charge_and_solvate.py
@@ -1,0 +1,58 @@
+import pytest
+from pdbfixer import PDBFixer
+import openmm.unit
+
+
+@pytest.mark.parametrize(
+    "pdbCode,soluteCharge",
+    [
+        ("1PO0", -21),
+        ("1A11", 1),
+        ("110D", -5),
+        ("1CNR", 0),
+        ("1ESD", -21),
+    ],
+)
+def test_charge_and_solvate(pdbCode, soluteCharge):
+    """
+    Test that downloadCharges and addSolvent successfully neutralise the system
+
+    Parameters
+    ----------
+    pdbCode : str
+        The PDB ID to test
+    soluteCharge : int
+        The formal charge of the solute - should equal the number of chloride
+        ions minus the number of sodium ions in the neutralised system. Note
+        that this may include ions from the original PDB entry.
+    """
+    fixer = PDBFixer(pdbid=pdbCode)
+    fixer.findMissingResidues()
+
+    chains_to_cap = {chain for chain, resi in fixer.missingResidues}
+    for chainidx in chains_to_cap:
+        chain = [*fixer.topology.chains()][chainidx]
+        last_resi = len([*chain.residues()])
+        # Capping with GLY because ACE/NME currently breaks addMissingHydrogens
+        # Adding a cap keeps the protein compact and the addSolvent call quick
+        fixer.missingResidues[chainidx, 0] = ["GLY"]
+        fixer.missingResidues[chainidx, last_resi] = ["GLY"]
+        # fixer.missingResidues[chainidx, 0] = ['ACE']
+        # fixer.missingResidues[chainidx, last_resi] = ['NME']
+
+    fixer.findNonstandardResidues()
+    fixer.replaceNonstandardResidues()
+    fixer.findMissingAtoms()
+    fixer.addMissingAtoms()
+
+    fixer.addMissingHydrogens(pH=7.4)
+    fixer.downloadCharges()
+    fixer.addSolvent(
+        padding=2.0 * openmm.unit.nanometer,
+        ionicStrength=0.1 * openmm.unit.molar,
+        boxShape="dodecahedron",
+    )
+
+    numCl = sum(1 for res in fixer.topology.residues() if res.name.lower() == "cl")
+    numNa = sum(1 for res in fixer.topology.residues() if res.name.lower() == "na")
+    assert soluteCharge == numCl - numNa


### PR DESCRIPTION
This PR addresses #299 by:

- Refactoring code that looks up the CCD into a single private method `_downloadCCDDefinition()` that parses and caches the definition.
- Adding the private method `_downloadFormalCharges()` which gets the formal charges of the atoms in a residue from the CCD
- Using `_downloadFormalCharges()` in `_createForceField(water=True)` to provide charges only when the residue is missing from the base force field and the (non-leaving) atom names in the CCD exactly match the atom names in the PDB
- Adding a test for the above behavior

The refactor avoids re-downloading a CCD entry up to 3 times (once for protonation, once for missing heavy atoms, and a third time for formal charge) and reduces duplicate code. However, it is not essential for the other functionality and can be removed or split into its own PR if desired.

This solution works around the issues discussed in #299 where CCD residues tend to hard-code a single protonation state by only using the CCD formal charge when the force field does not provide the residue. 

My reasoning is that there are two cases: first, when the force field includes a residue, it is capable of identifying the protonation state and gives the correct net charge and so it can only introduce regressions to interfere with this. In the second case, when a residue is introduced to the force field by `_createForceField(water=True)`, the atom's partial charge is currently hard-coded to 0 and so using more information to sometimes set that to better values is appropriate.

We can break down the effect of this change (modulo bugs) like so:

1. If an atom and residue is in `amber14-all.xml`, behavior is unchanged. Otherwise:
2. If an atom and residue is in the CCD and the PDB file is consistent with that definition and the atom is charged, this change corrects solvent neutralisation.
3. If a residue is in the CCD, and the PDB file re-uses identical residue and atom names for the entire residue, and that residue is neutral in the PDB but has a formal charge in the CCD, a regression is introduced. I expect this is very rare.
4. Otherwise, behavior is unchanged.

I think 2. should be much more common than 3., so this is a step in the right direction. In particular, in the very common case that PDBFixer is used to protonate a residue (with `addMissingHydrogens()`), this change guarantees that the protonation state will be consistent with the assumed charge - either both will be taken from the CCD, or the assumed charge will be inferred from the protonation state by the force field.

I think something like an `offsetCharge` argument to `addSolvent()` and `addMembrane()` which would allow a user to correct any remaining errors in neutralising charge would be great, but this requires changes to `Modeller` and so is not included in this PR.