### PR TITLE
Soft core force field includes torsions with wildcards

### DIFF
--- a/devtools/createSoftForcefield.py
+++ b/devtools/createSoftForcefield.py
@@ -51,18 +51,20 @@ print(' <AtomTypes>')
 omitTypes = set()
 omitClasses = set()
 for atomType in forcefield._atomTypes:
-    (atomClass, mass, element) = forcefield._atomTypes[atomType]
-    if element is None or element == elem.hydrogen:
+    data = forcefield._atomTypes[atomType]
+    if data.element is None or data.element == elem.hydrogen:
         omitTypes.add(atomType)
-        omitClasses.add(atomClass)
+        omitClasses.add(data.atomClass)
     else:
-        print('  <Type name="%s" class="%s" element="%s" mass="%g"/>' % (atomType, atomClass, element.symbol, mass))
+        print('  <Type name="%s" class="%s" element="%s" mass="%g"/>' % (atomType, data.atomClass, data.element.symbol, data.mass))
 print(' </AtomTypes>')
 
 # Print the residue templates.
 
 print(' <Residues>')
 for template in forcefield._templates.values():
+    if template.name in ('ASH', 'CYM', 'GLH', 'HID', 'HIE', 'LYN'):
+        continue
     print('  <Residue name="%s">' % template.name)
     atomIndex = {}
     for i, atom in enumerate(template.atoms):
@@ -86,8 +88,8 @@ for i in range(len(bonds.types1)):
     type1 = next(iter(bonds.types1[i]))
     type2 = next(iter(bonds.types2[i]))
     if type1 not in omitTypes and type2 not in omitTypes:
-        class1 = forcefield._atomTypes[type1][0]
-        class2 = forcefield._atomTypes[type2][0]
+        class1 = forcefield._atomTypes[type1].atomClass
+        class2 = forcefield._atomTypes[type2].atomClass
         print('  <Bond class1="%s" class2="%s" length="%g" k="%g"/>' % (class1, class2, bonds.length[i], bondK))
 print(' </HarmonicBondForce>')
 
@@ -100,9 +102,9 @@ for i in range(len(angles.types1)):
     type2 = next(iter(angles.types2[i]))
     type3 = next(iter(angles.types3[i]))
     if type1 not in omitTypes and type2 not in omitTypes and type3 not in omitTypes:
-        class1 = forcefield._atomTypes[type1][0]
-        class2 = forcefield._atomTypes[type2][0]
-        class3 = forcefield._atomTypes[type3][0]
+        class1 = forcefield._atomTypes[type1].atomClass
+        class2 = forcefield._atomTypes[type2].atomClass
+        class3 = forcefield._atomTypes[type3].atomClass
         print('  <Angle class1="%s" class2="%s" class3="%s" angle="%g" k="%g"/>' % (class1, class2, class3, angles.angle[i], angleK))
 print(' </HarmonicAngleForce>')
 
@@ -110,17 +112,13 @@ print(' </HarmonicAngleForce>')
 
 print(' <PeriodicTorsionForce>')
 torsions = [f for f in forcefield._forces if isinstance(f, ff.PeriodicTorsionGenerator)][0]
+wildcardType = forcefield._atomClasses['']
 for torsion in torsions.proper:
-    type1 = next(iter(torsion.types1))
-    type2 = next(iter(torsion.types2))
-    type3 = next(iter(torsion.types3))
-    type4= next(iter(torsion.types4))
-    if type1 not in omitTypes and type2 not in omitTypes and type3 not in omitTypes and type4 not in omitTypes:
-        class1 = forcefield._atomTypes[type1][0]
-        class2 = forcefield._atomTypes[type2][0]
-        class3 = forcefield._atomTypes[type3][0]
-        class4 = forcefield._atomTypes[type4][0]
-        print('  <Proper class1="%s" class2="%s" class3="%s" class4="%s"' % (class1, class2, class3, class4), end=' ')
+    type = [next(iter(torsion.types1)), next(iter(torsion.types2)), next(iter(torsion.types3)), next(iter(torsion.types4))]
+    wildcard = [torsion.types1 == wildcardType, torsion.types2 == wildcardType, torsion.types3 == wildcardType, torsion.types4 == wildcardType]
+    if all(type[i] not in omitTypes or wildcard[i] for i in range(4)):
+        classes = tuple('' if wildcard[i] else forcefield._atomTypes[type[i]].atomClass for i in range(4))
+        print('  <Proper class1="%s" class2="%s" class3="%s" class4="%s"' % classes, end=' ')
         for i in range(len(torsion.k)):
             print(' periodicity%d="%d" phase%d="%g" k%d="%g"' % (i+1, torsion.periodicity[i], i+1, torsion.phase[i], i+1, torsion.k[i]), end=' ')
         print('/>')
@@ -128,12 +126,12 @@ for torsion in torsions.improper:
     type1 = next(iter(torsion.types1))
     type2 = next(iter(torsion.types2))
     type3 = next(iter(torsion.types3))
-    type4= next(iter(torsion.types4))
+    type4 = next(iter(torsion.types4))
     if type1 not in omitTypes and type2 not in omitTypes and type3 not in omitTypes and type4 not in omitTypes:
-        class1 = forcefield._atomTypes[type1][0]
-        class2 = forcefield._atomTypes[type2][0]
-        class3 = forcefield._atomTypes[type3][0]
-        class4 = forcefield._atomTypes[type4][0]
+        class1 = forcefield._atomTypes[type1].atomClass
+        class2 = forcefield._atomTypes[type2].atomClass
+        class3 = forcefield._atomTypes[type3].atomClass
+        class4 = forcefield._atomTypes[type4].atomClass
         print('  <Improper class1="%s" class2="%s" class3="%s" class4="%s"' % (class1, class2, class3, class4), end=' ')
         for i in range(len(torsion.k)):
             print(' periodicity%d="%d" phase%d="%g" k%d="%g"' % (i+1, torsion.periodicity[i], i+1, torsion.phase[i], i+1, torsion.k[i]), end=' ')

--- a/devtools/createSoftForcefield.py
+++ b/devtools/createSoftForcefield.py
@@ -62,8 +62,9 @@ print(' </AtomTypes>')
 # Print the residue templates.
 
 print(' <Residues>')
+skipTemplates = ('ASH', 'CYM', 'GLH', 'HID', 'HIE', 'LYN')
 for template in forcefield._templates.values():
-    if template.name in ('ASH', 'CYM', 'GLH', 'HID', 'HIE', 'LYN'):
+    if template.name in skipTemplates or template.name[1:] in skipTemplates:
         continue
     print('  <Residue name="%s">' % template.name)
     atomIndex = {}
@@ -123,16 +124,11 @@ for torsion in torsions.proper:
             print(' periodicity%d="%d" phase%d="%g" k%d="%g"' % (i+1, torsion.periodicity[i], i+1, torsion.phase[i], i+1, torsion.k[i]), end=' ')
         print('/>')
 for torsion in torsions.improper:
-    type1 = next(iter(torsion.types1))
-    type2 = next(iter(torsion.types2))
-    type3 = next(iter(torsion.types3))
-    type4 = next(iter(torsion.types4))
-    if type1 not in omitTypes and type2 not in omitTypes and type3 not in omitTypes and type4 not in omitTypes:
-        class1 = forcefield._atomTypes[type1].atomClass
-        class2 = forcefield._atomTypes[type2].atomClass
-        class3 = forcefield._atomTypes[type3].atomClass
-        class4 = forcefield._atomTypes[type4].atomClass
-        print('  <Improper class1="%s" class2="%s" class3="%s" class4="%s"' % (class1, class2, class3, class4), end=' ')
+    type = [next(iter(torsion.types1)), next(iter(torsion.types2)), next(iter(torsion.types3)), next(iter(torsion.types4))]
+    wildcard = [torsion.types1 == wildcardType, torsion.types2 == wildcardType, torsion.types3 == wildcardType, torsion.types4 == wildcardType]
+    if all(type[i] not in omitTypes or wildcard[i] for i in range(4)):
+        classes = tuple('' if wildcard[i] else forcefield._atomTypes[type[i]].atomClass for i in range(4))
+        print('  <Improper class1="%s" class2="%s" class3="%s" class4="%s"' % classes, end=' ')
         for i in range(len(torsion.k)):
             print(' periodicity%d="%d" phase%d="%g" k%d="%g"' % (i+1, torsion.periodicity[i], i+1, torsion.phase[i], i+1, torsion.k[i]), end=' ')
         print('/>')

--- a/pdbfixer/soft.xml
+++ b/pdbfixer/soft.xml
@@ -1,509 +1,43 @@
 <ForceField>
  <AtomTypes>
-  <Type name="345" class="C" element="C" mass="12.0108"/>
-  <Type name="346" class="OH" element="O" mass="15.9994"/>
-  <Type name="340" class="CA" element="C" mass="12.0108"/>
-  <Type name="341" class="CA" element="C" mass="12.0108"/>
-  <Type name="343" class="CA" element="C" mass="12.0108"/>
-  <Type name="348" class="CA" element="C" mass="12.0108"/>
-  <Type name="1653" class="CT" element="C" mass="12.0108"/>
-  <Type name="298" class="O" element="O" mass="15.9994"/>
-  <Type name="299" class="N" element="N" mass="14.0067"/>
-  <Type name="297" class="C" element="C" mass="12.0108"/>
-  <Type name="295" class="OH" element="O" mass="15.9994"/>
-  <Type name="293" class="CT" element="C" mass="12.0108"/>
-  <Type name="291" class="CT" element="C" mass="12.0108"/>
-  <Type name="270" class="CA" element="C" mass="12.0108"/>
-  <Type name="272" class="CA" element="C" mass="12.0108"/>
-  <Type name="274" class="CA" element="C" mass="12.0108"/>
-  <Type name="276" class="C" element="C" mass="12.0108"/>
-  <Type name="277" class="O" element="O" mass="15.9994"/>
-  <Type name="278" class="N" element="N" mass="14.0067"/>
-  <Type name="279" class="CT" element="C" mass="12.0108"/>
-  <Type name="1780" class="OH" element="O" mass="15.9994"/>
-  <Type name="1781" class="CT" element="C" mass="12.0108"/>
-  <Type name="108" class="CT" element="C" mass="12.0108"/>
-  <Type name="102" class="C" element="C" mass="12.0108"/>
-  <Type name="103" class="O" element="O" mass="15.9994"/>
-  <Type name="100" class="OH" element="O" mass="15.9994"/>
-  <Type name="106" class="CT" element="C" mass="12.0108"/>
-  <Type name="104" class="N" element="N" mass="14.0067"/>
-  <Type name="1372" class="CT" element="C" mass="12.0108"/>
-  <Type name="1655" class="OH" element="O" mass="15.9994"/>
-  <Type name="1374" class="CT" element="C" mass="12.0108"/>
-  <Type name="99" class="O" element="O" mass="15.9994"/>
-  <Type name="98" class="C" element="C" mass="12.0108"/>
-  <Type name="90" class="N" element="N" mass="14.0067"/>
-  <Type name="92" class="CT" element="C" mass="12.0108"/>
-  <Type name="94" class="CT" element="C" mass="12.0108"/>
-  <Type name="96" class="CT" element="C" mass="12.0108"/>
-  <Type name="1622" class="CT" element="C" mass="12.0108"/>
-  <Type name="1621" class="O" element="O" mass="15.9994"/>
-  <Type name="1620" class="C" element="C" mass="12.0108"/>
-  <Type name="1626" class="OH" element="O" mass="15.9994"/>
-  <Type name="1624" class="CT" element="C" mass="12.0108"/>
-  <Type name="1629" class="P" element="P" mass="30.9738"/>
-  <Type name="1377" class="CT" element="C" mass="12.0108"/>
-  <Type name="559" class="N" element="N" mass="14.0067"/>
-  <Type name="558" class="O2" element="O" mass="15.9994"/>
-  <Type name="554" class="CT" element="C" mass="12.0108"/>
-  <Type name="557" class="O2" element="O" mass="15.9994"/>
-  <Type name="556" class="C" element="C" mass="12.0108"/>
-  <Type name="550" class="C4" element="C" mass="12.0108"/>
-  <Type name="552" class="CT" element="C" mass="12.0108"/>
-  <Type name="1191" class="C" element="C" mass="12.0108"/>
-  <Type name="1190" class="NC" element="N" mass="14.0067"/>
-  <Type name="1193" class="CT" element="C" mass="12.0108"/>
-  <Type name="1192" class="O" element="O" mass="15.9994"/>
-  <Type name="1195" class="CT" element="C" mass="12.0108"/>
-  <Type name="1197" class="OH" element="O" mass="15.9994"/>
-  <Type name="1758" class="CK" element="C" mass="12.0108"/>
-  <Type name="1757" class="N*" element="N" mass="14.0067"/>
-  <Type name="1755" class="CT" element="C" mass="12.0108"/>
-  <Type name="1754" class="OS" element="O" mass="15.9994"/>
-  <Type name="1752" class="CT" element="C" mass="12.0108"/>
-  <Type name="1750" class="CT" element="C" mass="12.0108"/>
-  <Type name="1177" class="CT" element="C" mass="12.0108"/>
-  <Type name="1175" class="CT" element="C" mass="12.0108"/>
-  <Type name="1174" class="OS" element="O" mass="15.9994"/>
-  <Type name="1173" class="O2" element="O" mass="15.9994"/>
-  <Type name="1172" class="O2" element="O" mass="15.9994"/>
-  <Type name="1171" class="P" element="P" mass="30.9738"/>
-  <Type name="1170" class="OS" element="O" mass="15.9994"/>
-  <Type name="1179" class="OS" element="O" mass="15.9994"/>
-  <Type name="511" class="N" element="N" mass="14.0067"/>
-  <Type name="510" class="O2" element="O" mass="15.9994"/>
-  <Type name="513" class="CT" element="C" mass="12.0108"/>
-  <Type name="1284" class="CT" element="C" mass="12.0108"/>
-  <Type name="1281" class="O2" element="O" mass="15.9994"/>
-  <Type name="1280" class="P" element="P" mass="30.9738"/>
-  <Type name="1283" class="OS" element="O" mass="15.9994"/>
-  <Type name="1282" class="O2" element="O" mass="15.9994"/>
-  <Type name="879" class="N3" element="N" mass="14.0067"/>
-  <Type name="1289" class="CT" element="C" mass="12.0108"/>
-  <Type name="1288" class="OS" element="O" mass="15.9994"/>
-  <Type name="1579" class="N*" element="N" mass="14.0067"/>
-  <Type name="689" class="O2" element="O" mass="15.9994"/>
-  <Type name="688" class="C" element="C" mass="12.0108"/>
-  <Type name="684" class="CA" element="C" mass="12.0108"/>
-  <Type name="686" class="CA" element="C" mass="12.0108"/>
-  <Type name="681" class="C" element="C" mass="12.0108"/>
-  <Type name="682" class="OH" element="O" mass="15.9994"/>
-  <Type name="458" class="CT" element="C" mass="12.0108"/>
-  <Type name="1226" class="CT" element="C" mass="12.0108"/>
-  <Type name="621" class="O2" element="O" mass="15.9994"/>
-  <Type name="873" class="CT" element="C" mass="12.0108"/>
-  <Type name="1223" class="OS" element="O" mass="15.9994"/>
-  <Type name="1221" class="CT" element="C" mass="12.0108"/>
-  <Type name="407" class="O2" element="O" mass="15.9994"/>
-  <Type name="406" class="O2" element="O" mass="15.9994"/>
-  <Type name="405" class="C" element="C" mass="12.0108"/>
-  <Type name="403" class="N" element="N" mass="14.0067"/>
-  <Type name="402" class="O" element="O" mass="15.9994"/>
-  <Type name="401" class="C5" element="C" mass="12.0108"/>
-  <Type name="1379" class="N*" element="N" mass="14.0067"/>
-  <Type name="408" class="N" element="N" mass="14.0067"/>
-  <Type name="453" class="C" element="C" mass="12.0108"/>
-  <Type name="454" class="O2" element="O" mass="15.9994"/>
-  <Type name="455" class="O2" element="O" mass="15.9994"/>
-  <Type name="1346" class="CT" element="C" mass="12.0108"/>
-  <Type name="379" class="CT" element="C" mass="12.0108"/>
-  <Type name="370" class="CT" element="C" mass="12.0108"/>
-  <Type name="373" class="O2" element="O" mass="15.9994"/>
-  <Type name="372" class="C" element="C" mass="12.0108"/>
-  <Type name="375" class="N" element="N" mass="14.0067"/>
-  <Type name="374" class="O2" element="O" mass="15.9994"/>
-  <Type name="377" class="CT" element="C" mass="12.0108"/>
-  <Type name="393" class="O2" element="O" mass="15.9994"/>
-  <Type name="392" class="C" element="C" mass="12.0108"/>
-  <Type name="390" class="N2" element="N" mass="14.0067"/>
-  <Type name="397" class="CT" element="C" mass="12.0108"/>
-  <Type name="395" class="N" element="N" mass="14.0067"/>
-  <Type name="394" class="O2" element="O" mass="15.9994"/>
-  <Type name="399" class="CT" element="C" mass="12.0108"/>
-  <Type name="895" class="CT" element="C" mass="12.0108"/>
-  <Type name="245" class="O" element="O" mass="15.9994"/>
-  <Type name="244" class="C" element="C" mass="12.0108"/>
-  <Type name="246" class="N" element="N" mass="14.0067"/>
-  <Type name="240" class="CT" element="C" mass="12.0108"/>
-  <Type name="242" class="N3" element="N" mass="14.0067"/>
-  <Type name="248" class="CT" element="C" mass="12.0108"/>
-  <Type name="178" class="CR" element="C" mass="12.0108"/>
-  <Type name="176" class="NA" element="N" mass="14.0067"/>
-  <Type name="175" class="CC" element="C" mass="12.0108"/>
-  <Type name="173" class="CT" element="C" mass="12.0108"/>
-  <Type name="171" class="CT" element="C" mass="12.0108"/>
-  <Type name="1502" class="CT" element="C" mass="12.0108"/>
-  <Type name="1500" class="NC" element="N" mass="14.0067"/>
-  <Type name="1501" class="CB" element="C" mass="12.0108"/>
-  <Type name="1506" class="OH" element="O" mass="15.9994"/>
-  <Type name="1504" class="CT" element="C" mass="12.0108"/>
-  <Type name="1619" class="NC" element="N" mass="14.0067"/>
-  <Type name="1616" class="CA" element="C" mass="12.0108"/>
-  <Type name="1617" class="N2" element="N" mass="14.0067"/>
-  <Type name="1614" class="CM" element="C" mass="12.0108"/>
-  <Type name="1612" class="CM" element="C" mass="12.0108"/>
-  <Type name="1611" class="N*" element="N" mass="14.0067"/>
-  <Type name="1769" class="NC" element="N" mass="14.0067"/>
-  <Type name="1762" class="C" element="C" mass="12.0108"/>
-  <Type name="1763" class="O" element="O" mass="15.9994"/>
-  <Type name="1760" class="NB" element="N" mass="14.0067"/>
-  <Type name="1761" class="CB" element="C" mass="12.0108"/>
-  <Type name="1766" class="CA" element="C" mass="12.0108"/>
-  <Type name="1767" class="N2" element="N" mass="14.0067"/>
-  <Type name="1764" class="NA" element="N" mass="14.0067"/>
-  <Type name="1142" class="OH" element="O" mass="15.9994"/>
-  <Type name="1140" class="CT" element="C" mass="12.0108"/>
-  <Type name="1146" class="O2" element="O" mass="15.9994"/>
-  <Type name="1147" class="OS" element="O" mass="15.9994"/>
-  <Type name="1144" class="P" element="P" mass="30.9738"/>
-  <Type name="1145" class="O2" element="O" mass="15.9994"/>
-  <Type name="1148" class="CT" element="C" mass="12.0108"/>
-  <Type name="693" class="CT" element="C" mass="12.0108"/>
-  <Type name="690" class="O2" element="O" mass="15.9994"/>
-  <Type name="691" class="N" element="N" mass="14.0067"/>
-  <Type name="697" class="CT" element="C" mass="12.0108"/>
-  <Type name="695" class="CT" element="C" mass="12.0108"/>
-  <Type name="699" class="CT" element="C" mass="12.0108"/>
-  <Type name="1548" class="CT" element="C" mass="12.0108"/>
-  <Type name="542" class="O2" element="O" mass="15.9994"/>
-  <Type name="543" class="O2" element="O" mass="15.9994"/>
-  <Type name="541" class="C" element="C" mass="12.0108"/>
-  <Type name="546" class="CT" element="C" mass="12.0108"/>
-  <Type name="544" class="N" element="N" mass="14.0067"/>
-  <Type name="548" class="CT" element="C" mass="12.0108"/>
-  <Type name="1783" class="CT" element="C" mass="12.0108"/>
-  <Type name="1785" class="OS" element="O" mass="15.9994"/>
-  <Type name="1786" class="CT" element="C" mass="12.0108"/>
-  <Type name="414" class="C6" element="C" mass="12.0108"/>
-  <Type name="415" class="O2" element="O" mass="15.9994"/>
-  <Type name="416" class="O2" element="O" mass="15.9994"/>
-  <Type name="417" class="C" element="C" mass="12.0108"/>
-  <Type name="410" class="CT" element="C" mass="12.0108"/>
-  <Type name="412" class="CT" element="C" mass="12.0108"/>
-  <Type name="1385" class="C" element="C" mass="12.0108"/>
-  <Type name="1386" class="O" element="O" mass="15.9994"/>
-  <Type name="1387" class="NA" element="N" mass="14.0067"/>
-  <Type name="418" class="O2" element="O" mass="15.9994"/>
-  <Type name="419" class="O2" element="O" mass="15.9994"/>
-  <Type name="1382" class="CM" element="C" mass="12.0108"/>
-  <Type name="1383" class="CT" element="C" mass="12.0108"/>
-  <Type name="tip3p-O" class="OW" element="O" mass="15.9994"/>
-  <Type name="368" class="CT" element="C" mass="12.0108"/>
-  <Type name="366" class="N" element="N" mass="14.0067"/>
-  <Type name="364" class="C" element="C" mass="12.0108"/>
-  <Type name="365" class="O" element="O" mass="15.9994"/>
-  <Type name="362" class="CT" element="C" mass="12.0108"/>
-  <Type name="360" class="CT" element="C" mass="12.0108"/>
-  <Type name="381" class="CT" element="C" mass="12.0108"/>
-  <Type name="383" class="CT" element="C" mass="12.0108"/>
-  <Type name="385" class="N2" element="N" mass="14.0067"/>
-  <Type name="387" class="CA" element="C" mass="12.0108"/>
-  <Type name="388" class="N2" element="N" mass="14.0067"/>
-  <Type name="258" class="O" element="O" mass="15.9994"/>
-  <Type name="259" class="N" element="N" mass="14.0067"/>
-  <Type name="252" class="CT" element="C" mass="12.0108"/>
-  <Type name="250" class="CT" element="C" mass="12.0108"/>
-  <Type name="257" class="C" element="C" mass="12.0108"/>
-  <Type name="254" class="S" element="S" mass="32.0655"/>
-  <Type name="255" class="CT" element="C" mass="12.0108"/>
-  <Type name="1679" class="CT" element="C" mass="12.0108"/>
-  <Type name="1849" class="CT" element="C" mass="12.0108"/>
-  <Type name="1848" class="OS" element="O" mass="15.9994"/>
-  <Type name="168" class="O" element="O" mass="15.9994"/>
-  <Type name="169" class="N" element="N" mass="14.0067"/>
-  <Type name="165" class="CW" element="C" mass="12.0108"/>
-  <Type name="167" class="C" element="C" mass="12.0108"/>
-  <Type name="160" class="NB" element="N" mass="14.0067"/>
-  <Type name="161" class="CR" element="C" mass="12.0108"/>
-  <Type name="163" class="NA" element="N" mass="14.0067"/>
-  <Type name="1842" class="O2" element="O" mass="15.9994"/>
-  <Type name="1841" class="O2" element="O" mass="15.9994"/>
-  <Type name="1840" class="P" element="P" mass="30.9738"/>
-  <Type name="679" class="CA" element="C" mass="12.0108"/>
-  <Type name="1815" class="OS" element="O" mass="15.9994"/>
-  <Type name="1816" class="CT" element="C" mass="12.0108"/>
-  <Type name="1810" class="OH" element="O" mass="15.9994"/>
-  <Type name="1811" class="CT" element="C" mass="12.0108"/>
-  <Type name="1813" class="CT" element="C" mass="12.0108"/>
-  <Type name="1818" class="N*" element="N" mass="14.0067"/>
-  <Type name="1819" class="CK" element="C" mass="12.0108"/>
-  <Type name="670" class="N" element="N" mass="14.0067"/>
-  <Type name="1609" class="CT" element="C" mass="12.0108"/>
-  <Type name="1608" class="OS" element="O" mass="15.9994"/>
-  <Type name="1601" class="O2" element="O" mass="15.9994"/>
-  <Type name="1600" class="P" element="P" mass="30.9738"/>
-  <Type name="1603" class="OS" element="O" mass="15.9994"/>
-  <Type name="1602" class="O2" element="O" mass="15.9994"/>
-  <Type name="1604" class="CT" element="C" mass="12.0108"/>
-  <Type name="1606" class="CT" element="C" mass="12.0108"/>
-  <Type name="809" class="O" element="O" mass="15.9994"/>
-  <Type name="808" class="C" element="C" mass="12.0108"/>
-  <Type name="803" class="CT" element="C" mass="12.0108"/>
-  <Type name="801" class="CT" element="C" mass="12.0108"/>
-  <Type name="807" class="O2" element="O" mass="15.9994"/>
-  <Type name="806" class="O2" element="O" mass="15.9994"/>
-  <Type name="805" class="C" element="C" mass="12.0108"/>
-  <Type name="1775" class="OH" element="O" mass="15.9994"/>
-  <Type name="1777" class="OH" element="O" mass="15.9994"/>
-  <Type name="1771" class="CT" element="C" mass="12.0108"/>
-  <Type name="1770" class="CB" element="C" mass="12.0108"/>
-  <Type name="1773" class="CT" element="C" mass="12.0108"/>
-  <Type name="608" class="O2" element="O" mass="15.9994"/>
-  <Type name="1158" class="CM" element="C" mass="12.0108"/>
-  <Type name="1155" class="N*" element="N" mass="14.0067"/>
-  <Type name="1156" class="CM" element="C" mass="12.0108"/>
-  <Type name="1150" class="CT" element="C" mass="12.0108"/>
-  <Type name="1153" class="CT" element="C" mass="12.0108"/>
-  <Type name="1152" class="OS" element="O" mass="15.9994"/>
-  <Type name="1555" class="CA" element="C" mass="12.0108"/>
-  <Type name="1554" class="CB" element="C" mass="12.0108"/>
-  <Type name="1551" class="CK" element="C" mass="12.0108"/>
-  <Type name="1550" class="N*" element="N" mass="14.0067"/>
-  <Type name="1553" class="NB" element="N" mass="14.0067"/>
-  <Type name="59" class="O2" element="O" mass="15.9994"/>
-  <Type name="58" class="O2" element="O" mass="15.9994"/>
-  <Type name="1556" class="N2" element="N" mass="14.0067"/>
-  <Type name="55" class="CT" element="C" mass="12.0108"/>
-  <Type name="57" class="C6" element="C" mass="12.0108"/>
-  <Type name="51" class="N" element="N" mass="14.0067"/>
-  <Type name="50" class="O" element="O" mass="15.9994"/>
-  <Type name="53" class="CT" element="C" mass="12.0108"/>
-  <Type name="537" class="CT" element="C" mass="12.0108"/>
-  <Type name="535" class="CT" element="C" mass="12.0108"/>
-  <Type name="533" class="CT" element="C" mass="12.0108"/>
-  <Type name="531" class="CT" element="C" mass="12.0108"/>
-  <Type name="539" class="CT" element="C" mass="12.0108"/>
-  <Type name="1558" class="NC" element="N" mass="14.0067"/>
-  <Type name="429" class="O2" element="O" mass="15.9994"/>
-  <Type name="428" class="C" element="C" mass="12.0108"/>
-  <Type name="1399" class="OS" element="O" mass="15.9994"/>
-  <Type name="1398" class="O2" element="O" mass="15.9994"/>
-  <Type name="420" class="N" element="N" mass="14.0067"/>
-  <Type name="422" class="CT" element="C" mass="12.0108"/>
-  <Type name="424" class="CT" element="C" mass="12.0108"/>
-  <Type name="426" class="SH" element="S" mass="32.0655"/>
-  <Type name="229" class="O" element="O" mass="15.9994"/>
-  <Type name="228" class="C" element="C" mass="12.0108"/>
-  <Type name="226" class="N3" element="N" mass="14.0067"/>
-  <Type name="224" class="CT" element="C" mass="12.0108"/>
-  <Type name="222" class="CT" element="C" mass="12.0108"/>
-  <Type name="220" class="CT" element="C" mass="12.0108"/>
-  <Type name="151" class="C" element="C" mass="12.0108"/>
-  <Type name="153" class="N" element="N" mass="14.0067"/>
-  <Type name="152" class="O" element="O" mass="15.9994"/>
-  <Type name="155" class="CT" element="C" mass="12.0108"/>
-  <Type name="157" class="CT" element="C" mass="12.0108"/>
-  <Type name="159" class="CC" element="C" mass="12.0108"/>
-  <Type name="1806" class="OH" element="O" mass="15.9994"/>
-  <Type name="1804" class="CT" element="C" mass="12.0108"/>
-  <Type name="1802" class="CT" element="C" mass="12.0108"/>
-  <Type name="1801" class="CB" element="C" mass="12.0108"/>
-  <Type name="1800" class="NC" element="N" mass="14.0067"/>
-  <Type name="1808" class="OS" element="O" mass="15.9994"/>
-  <Type name="1524" class="CB" element="C" mass="12.0108"/>
-  <Type name="1948" class="CT" element="C" mass="12.0108"/>
-  <Type name="1525" class="CA" element="C" mass="12.0108"/>
-  <Type name="1942" class="NA" element="N" mass="14.0067"/>
-  <Type name="1940" class="C" element="C" mass="12.0108"/>
-  <Type name="1941" class="O" element="O" mass="15.9994"/>
-  <Type name="1946" class="CT" element="C" mass="12.0108"/>
-  <Type name="1526" class="N2" element="N" mass="14.0067"/>
-  <Type name="1944" class="C" element="C" mass="12.0108"/>
-  <Type name="1945" class="O" element="O" mass="15.9994"/>
-  <Type name="818" class="CT" element="C" mass="12.0108"/>
   <Type name="0" class="N" element="N" mass="14.0067"/>
-  <Type name="810" class="N3" element="N" mass="14.0067"/>
-  <Type name="812" class="CT" element="C" mass="12.0108"/>
-  <Type name="814" class="C" element="C" mass="12.0108"/>
-  <Type name="815" class="O" element="O" mass="15.9994"/>
-  <Type name="816" class="N3" element="N" mass="14.0067"/>
-  <Type name="1545" class="CT" element="C" mass="12.0108"/>
-  <Type name="1523" class="NB" element="N" mass="14.0067"/>
-  <Type name="1490" class="CK" element="C" mass="12.0108"/>
-  <Type name="1397" class="O2" element="O" mass="15.9994"/>
-  <Type name="1492" class="NB" element="N" mass="14.0067"/>
-  <Type name="1493" class="CB" element="C" mass="12.0108"/>
-  <Type name="1494" class="CA" element="C" mass="12.0108"/>
-  <Type name="1495" class="N2" element="N" mass="14.0067"/>
-  <Type name="1396" class="P" element="P" mass="30.9738"/>
-  <Type name="1498" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1395" class="OS" element="O" mass="15.9994"/>
-  <Type name="1700" class="CA" element="C" mass="12.0108"/>
-  <Type name="1701" class="N2" element="N" mass="14.0067"/>
-  <Type name="1704" class="C" element="C" mass="12.0108"/>
-  <Type name="1705" class="O" element="O" mass="15.9994"/>
-  <Type name="1706" class="CT" element="C" mass="12.0108"/>
-  <Type name="1708" class="CT" element="C" mass="12.0108"/>
-  <Type name="1393" class="CT" element="C" mass="12.0108"/>
-  <Type name="1391" class="CT" element="C" mass="12.0108"/>
-  <Type name="1390" class="O" element="O" mass="15.9994"/>
-  <Type name="1128" class="NB" element="N" mass="14.0067"/>
-  <Type name="1129" class="CB" element="C" mass="12.0108"/>
-  <Type name="1628" class="OS" element="O" mass="15.9994"/>
-  <Type name="1120" class="CT" element="C" mass="12.0108"/>
-  <Type name="1122" class="OS" element="O" mass="15.9994"/>
-  <Type name="1123" class="CT" element="C" mass="12.0108"/>
-  <Type name="1125" class="N*" element="N" mass="14.0067"/>
-  <Type name="1126" class="CK" element="C" mass="12.0108"/>
-  <Type name="524" class="CW" element="C" mass="12.0108"/>
-  <Type name="526" class="C" element="C" mass="12.0108"/>
-  <Type name="527" class="O2" element="O" mass="15.9994"/>
-  <Type name="520" class="CR" element="C" mass="12.0108"/>
-  <Type name="522" class="NA" element="N" mass="14.0067"/>
-  <Type name="1014" class="CA" element="C" mass="12.0108"/>
-  <Type name="1016" class="C" element="C" mass="12.0108"/>
-  <Type name="1017" class="O" element="O" mass="15.9994"/>
-  <Type name="528" class="O2" element="O" mass="15.9994"/>
-  <Type name="529" class="N" element="N" mass="14.0067"/>
-  <Type name="1012" class="CA" element="C" mass="12.0108"/>
-  <Type name="1234" class="CM" element="C" mass="12.0108"/>
-  <Type name="1236" class="CM" element="C" mass="12.0108"/>
-  <Type name="1230" class="OS" element="O" mass="15.9994"/>
-  <Type name="1231" class="CT" element="C" mass="12.0108"/>
-  <Type name="1233" class="N*" element="N" mass="14.0067"/>
-  <Type name="1238" class="CA" element="C" mass="12.0108"/>
-  <Type name="1239" class="N2" element="N" mass="14.0067"/>
-  <Type name="438" class="C" element="C" mass="12.0108"/>
-  <Type name="439" class="O2" element="O" mass="15.9994"/>
-  <Type name="437" class="S" element="S" mass="32.0655"/>
-  <Type name="435" class="CT" element="C" mass="12.0108"/>
-  <Type name="433" class="CT" element="C" mass="12.0108"/>
-  <Type name="430" class="O2" element="O" mass="15.9994"/>
-  <Type name="431" class="N" element="N" mass="14.0067"/>
-  <Type name="1960" class="Rb" element="Rb" mass="85.4678"/>
-  <Type name="238" class="CT" element="C" mass="12.0108"/>
-  <Type name="234" class="CT" element="C" mass="12.0108"/>
-  <Type name="236" class="CT" element="C" mass="12.0108"/>
-  <Type name="230" class="N" element="N" mass="14.0067"/>
-  <Type name="232" class="CT" element="C" mass="12.0108"/>
-  <Type name="146" class="CR" element="C" mass="12.0108"/>
-  <Type name="144" class="NA" element="N" mass="14.0067"/>
-  <Type name="143" class="CC" element="C" mass="12.0108"/>
-  <Type name="141" class="CT" element="C" mass="12.0108"/>
-  <Type name="148" class="NB" element="N" mass="14.0067"/>
-  <Type name="149" class="CV" element="C" mass="12.0108"/>
-  <Type name="1832" class="CT" element="C" mass="12.0108"/>
-  <Type name="1830" class="NC" element="N" mass="14.0067"/>
-  <Type name="1831" class="CB" element="C" mass="12.0108"/>
-  <Type name="1836" class="OH" element="O" mass="15.9994"/>
-  <Type name="1834" class="CT" element="C" mass="12.0108"/>
-  <Type name="1838" class="OH" element="O" mass="15.9994"/>
-  <Type name="939" class="C" element="C" mass="12.0108"/>
-  <Type name="933" class="CA" element="C" mass="12.0108"/>
-  <Type name="931" class="CA" element="C" mass="12.0108"/>
-  <Type name="937" class="CA" element="C" mass="12.0108"/>
-  <Type name="935" class="CA" element="C" mass="12.0108"/>
-  <Type name="1955" class="Cs" element="Cs" mass="132.905"/>
-  <Type name="1954" class="IM" element="Cl" mass="35.4532"/>
-  <Type name="1957" class="Li" element="Li" mass="6.9412"/>
-  <Type name="1956" class="K" element="K" mass="39.0983"/>
-  <Type name="1950" class="OH" element="O" mass="15.9994"/>
-  <Type name="1952" class="OH" element="O" mass="15.9994"/>
-  <Type name="1959" class="IP" element="Na" mass="22.9898"/>
-  <Type name="1958" class="MG" element="Mg" mass="24.3051"/>
-  <Type name="828" class="CV" element="C" mass="12.0108"/>
-  <Type name="825" class="CR" element="C" mass="12.0108"/>
-  <Type name="827" class="NB" element="N" mass="14.0067"/>
-  <Type name="820" class="CT" element="C" mass="12.0108"/>
-  <Type name="823" class="NA" element="N" mass="14.0067"/>
-  <Type name="822" class="CC" element="C" mass="12.0108"/>
-  <Type name="1482" class="CT" element="C" mass="12.0108"/>
-  <Type name="1481" class="OS" element="O" mass="15.9994"/>
-  <Type name="1480" class="O2" element="O" mass="15.9994"/>
-  <Type name="1487" class="CT" element="C" mass="12.0108"/>
-  <Type name="1486" class="OS" element="O" mass="15.9994"/>
-  <Type name="1484" class="CT" element="C" mass="12.0108"/>
-  <Type name="1489" class="N*" element="N" mass="14.0067"/>
-  <Type name="797" class="N3" element="N" mass="14.0067"/>
-  <Type name="796" class="O" element="O" mass="15.9994"/>
-  <Type name="795" class="C" element="C" mass="12.0108"/>
-  <Type name="793" class="N" element="N" mass="14.0067"/>
-  <Type name="792" class="O" element="O" mass="15.9994"/>
-  <Type name="791" class="C" element="C" mass="12.0108"/>
-  <Type name="1718" class="CT" element="C" mass="12.0108"/>
-  <Type name="799" class="CT" element="C" mass="12.0108"/>
-  <Type name="1270" class="CA" element="C" mass="12.0108"/>
-  <Type name="1271" class="N2" element="N" mass="14.0067"/>
-  <Type name="1138" class="CT" element="C" mass="12.0108"/>
-  <Type name="1133" class="NC" element="N" mass="14.0067"/>
-  <Type name="1131" class="N2" element="N" mass="14.0067"/>
-  <Type name="1130" class="CA" element="C" mass="12.0108"/>
-  <Type name="1137" class="CB" element="C" mass="12.0108"/>
-  <Type name="1136" class="NC" element="N" mass="14.0067"/>
-  <Type name="1134" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1277" class="CT" element="C" mass="12.0108"/>
-  <Type name="518" class="NA" element="N" mass="14.0067"/>
-  <Type name="1009" class="C" element="C" mass="12.0108"/>
-  <Type name="1007" class="CA" element="C" mass="12.0108"/>
-  <Type name="1005" class="CA" element="C" mass="12.0108"/>
-  <Type name="1004" class="CA" element="C" mass="12.0108"/>
-  <Type name="515" class="CT" element="C" mass="12.0108"/>
-  <Type name="1002" class="CT" element="C" mass="12.0108"/>
-  <Type name="517" class="CC" element="C" mass="12.0108"/>
-  <Type name="1000" class="CT" element="C" mass="12.0108"/>
-  <Type name="622" class="N" element="N" mass="14.0067"/>
-  <Type name="1225" class="OH" element="O" mass="15.9994"/>
-  <Type name="620" class="O2" element="O" mass="15.9994"/>
-  <Type name="626" class="CT" element="C" mass="12.0108"/>
-  <Type name="624" class="CT" element="C" mass="12.0108"/>
-  <Type name="628" class="OH" element="O" mass="15.9994"/>
-  <Type name="1228" class="CT" element="C" mass="12.0108"/>
-  <Type name="1535" class="CT" element="C" mass="12.0108"/>
   <Type name="2" class="CT" element="C" mass="12.0108"/>
-  <Type name="1286" class="CT" element="C" mass="12.0108"/>
+  <Type name="4" class="CT" element="C" mass="12.0108"/>
+  <Type name="6" class="C" element="C" mass="12.0108"/>
+  <Type name="7" class="O" element="O" mass="15.9994"/>
+  <Type name="8" class="N" element="N" mass="14.0067"/>
   <Type name="10" class="CT" element="C" mass="12.0108"/>
   <Type name="12" class="CT" element="C" mass="12.0108"/>
   <Type name="14" class="CT" element="C" mass="12.0108"/>
   <Type name="16" class="CT" element="C" mass="12.0108"/>
   <Type name="18" class="N2" element="N" mass="14.0067"/>
-  <Type name="200" class="N" element="N" mass="14.0067"/>
-  <Type name="202" class="CT" element="C" mass="12.0108"/>
-  <Type name="204" class="CT" element="C" mass="12.0108"/>
-  <Type name="206" class="C4" element="C" mass="12.0108"/>
-  <Type name="208" class="CT" element="C" mass="12.0108"/>
-  <Type name="1572" class="CT" element="C" mass="12.0108"/>
-  <Type name="1571" class="OH" element="O" mass="15.9994"/>
-  <Type name="1577" class="CT" element="C" mass="12.0108"/>
-  <Type name="1576" class="OS" element="O" mass="15.9994"/>
-  <Type name="1574" class="CT" element="C" mass="12.0108"/>
-  <Type name="1828" class="N2" element="N" mass="14.0067"/>
-  <Type name="1825" class="NA" element="N" mass="14.0067"/>
-  <Type name="1824" class="O" element="O" mass="15.9994"/>
-  <Type name="1827" class="CA" element="C" mass="12.0108"/>
-  <Type name="1821" class="NB" element="N" mass="14.0067"/>
-  <Type name="1823" class="C" element="C" mass="12.0108"/>
-  <Type name="1822" class="CB" element="C" mass="12.0108"/>
-  <Type name="928" class="CA" element="C" mass="12.0108"/>
-  <Type name="929" class="CA" element="C" mass="12.0108"/>
-  <Type name="920" class="C" element="C" mass="12.0108"/>
-  <Type name="921" class="O" element="O" mass="15.9994"/>
-  <Type name="922" class="N3" element="N" mass="14.0067"/>
-  <Type name="924" class="CT" element="C" mass="12.0108"/>
-  <Type name="926" class="CT" element="C" mass="12.0108"/>
-  <Type name="1921" class="CT" element="C" mass="12.0108"/>
-  <Type name="1923" class="OH" element="O" mass="15.9994"/>
-  <Type name="1925" class="OS" element="O" mass="15.9994"/>
-  <Type name="1927" class="OH" element="O" mass="15.9994"/>
-  <Type name="1928" class="CT" element="C" mass="12.0108"/>
-  <Type name="832" class="N3" element="N" mass="14.0067"/>
-  <Type name="830" class="C" element="C" mass="12.0108"/>
-  <Type name="831" class="O" element="O" mass="15.9994"/>
-  <Type name="836" class="CT" element="C" mass="12.0108"/>
-  <Type name="834" class="CT" element="C" mass="12.0108"/>
-  <Type name="838" class="CC" element="C" mass="12.0108"/>
-  <Type name="839" class="NB" element="N" mass="14.0067"/>
-  <Type name="1532" class="CB" element="C" mass="12.0108"/>
-  <Type name="785" class="CT" element="C" mass="12.0108"/>
-  <Type name="787" class="CT" element="C" mass="12.0108"/>
-  <Type name="780" class="S" element="S" mass="32.0655"/>
-  <Type name="781" class="C" element="C" mass="12.0108"/>
-  <Type name="782" class="O" element="O" mass="15.9994"/>
-  <Type name="783" class="N3" element="N" mass="14.0067"/>
-  <Type name="1726" class="CK" element="C" mass="12.0108"/>
-  <Type name="1725" class="N*" element="N" mass="14.0067"/>
-  <Type name="789" class="CT" element="C" mass="12.0108"/>
-  <Type name="1720" class="CT" element="C" mass="12.0108"/>
+  <Type name="20" class="CA" element="C" mass="12.0108"/>
+  <Type name="21" class="N2" element="N" mass="14.0067"/>
+  <Type name="23" class="N2" element="N" mass="14.0067"/>
+  <Type name="25" class="C" element="C" mass="12.0108"/>
+  <Type name="26" class="O" element="O" mass="15.9994"/>
+  <Type name="27" class="N" element="N" mass="14.0067"/>
+  <Type name="29" class="CT" element="C" mass="12.0108"/>
+  <Type name="31" class="CT" element="C" mass="12.0108"/>
+  <Type name="33" class="C" element="C" mass="12.0108"/>
+  <Type name="34" class="O" element="O" mass="15.9994"/>
+  <Type name="35" class="OH" element="O" mass="15.9994"/>
+  <Type name="37" class="C" element="C" mass="12.0108"/>
+  <Type name="38" class="O" element="O" mass="15.9994"/>
+  <Type name="39" class="N" element="N" mass="14.0067"/>
+  <Type name="41" class="CT" element="C" mass="12.0108"/>
+  <Type name="43" class="CT" element="C" mass="12.0108"/>
+  <Type name="45" class="C5" element="C" mass="12.0108"/>
+  <Type name="46" class="O" element="O" mass="15.9994"/>
+  <Type name="47" class="N" element="N" mass="14.0067"/>
+  <Type name="49" class="C" element="C" mass="12.0108"/>
+  <Type name="50" class="O" element="O" mass="15.9994"/>
+  <Type name="51" class="N" element="N" mass="14.0067"/>
+  <Type name="53" class="CT" element="C" mass="12.0108"/>
+  <Type name="55" class="CT" element="C" mass="12.0108"/>
+  <Type name="57" class="C6" element="C" mass="12.0108"/>
+  <Type name="58" class="O2" element="O" mass="15.9994"/>
+  <Type name="59" class="O2" element="O" mass="15.9994"/>
   <Type name="60" class="C" element="C" mass="12.0108"/>
   <Type name="61" class="O" element="O" mass="15.9994"/>
   <Type name="62" class="N" element="N" mass="14.0067"/>
@@ -511,604 +45,38 @@
   <Type name="66" class="CT" element="C" mass="12.0108"/>
   <Type name="68" class="SH" element="S" mass="32.0655"/>
   <Type name="69" class="C" element="C" mass="12.0108"/>
-  <Type name="1371" class="OS" element="O" mass="15.9994"/>
-  <Type name="1588" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1370" class="O2" element="O" mass="15.9994"/>
-  <Type name="1582" class="NB" element="N" mass="14.0067"/>
-  <Type name="1583" class="CB" element="C" mass="12.0108"/>
-  <Type name="1580" class="CK" element="C" mass="12.0108"/>
-  <Type name="1584" class="CA" element="C" mass="12.0108"/>
-  <Type name="1585" class="N2" element="N" mass="14.0067"/>
-  <Type name="1038" class="OS" element="O" mass="15.9994"/>
-  <Type name="1039" class="CT" element="C" mass="12.0108"/>
-  <Type name="508" class="C" element="C" mass="12.0108"/>
-  <Type name="509" class="O2" element="O" mass="15.9994"/>
-  <Type name="1032" class="O2" element="O" mass="15.9994"/>
-  <Type name="1030" class="P" element="P" mass="30.9738"/>
-  <Type name="502" class="CR" element="C" mass="12.0108"/>
-  <Type name="500" class="CC" element="C" mass="12.0108"/>
-  <Type name="501" class="NB" element="N" mass="14.0067"/>
-  <Type name="1213" class="CA" element="C" mass="12.0108"/>
-  <Type name="632" class="O2" element="O" mass="15.9994"/>
-  <Type name="633" class="N" element="N" mass="14.0067"/>
-  <Type name="1216" class="NC" element="N" mass="14.0067"/>
-  <Type name="1217" class="C" element="C" mass="12.0108"/>
-  <Type name="637" class="CT" element="C" mass="12.0108"/>
-  <Type name="639" class="CT" element="C" mass="12.0108"/>
-  <Type name="1218" class="O" element="O" mass="15.9994"/>
-  <Type name="1219" class="CT" element="C" mass="12.0108"/>
-  <Type name="465" class="O2" element="O" mass="15.9994"/>
-  <Type name="1728" class="NB" element="N" mass="14.0067"/>
-  <Type name="1729" class="CB" element="C" mass="12.0108"/>
-  <Type name="1106" class="NC" element="N" mass="14.0067"/>
-  <Type name="1107" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1104" class="N2" element="N" mass="14.0067"/>
-  <Type name="1102" class="CB" element="C" mass="12.0108"/>
-  <Type name="1103" class="CA" element="C" mass="12.0108"/>
-  <Type name="1101" class="NB" element="N" mass="14.0067"/>
-  <Type name="1458" class="CT" element="C" mass="12.0108"/>
-  <Type name="1109" class="NC" element="N" mass="14.0067"/>
-  <Type name="1722" class="OS" element="O" mass="15.9994"/>
-  <Type name="1723" class="CT" element="C" mass="12.0108"/>
-  <Type name="1897" class="OH" element="O" mass="15.9994"/>
-  <Type name="1891" class="CT" element="C" mass="12.0108"/>
-  <Type name="216" class="CT" element="C" mass="12.0108"/>
-  <Type name="214" class="N" element="N" mass="14.0067"/>
-  <Type name="212" class="C" element="C" mass="12.0108"/>
-  <Type name="213" class="O" element="O" mass="15.9994"/>
-  <Type name="210" class="CT" element="C" mass="12.0108"/>
-  <Type name="218" class="CT" element="C" mass="12.0108"/>
-  <Type name="4" class="CT" element="C" mass="12.0108"/>
-  <Type name="1858" class="NA" element="N" mass="14.0067"/>
-  <Type name="1851" class="N*" element="N" mass="14.0067"/>
-  <Type name="1852" class="CM" element="C" mass="12.0108"/>
-  <Type name="1854" class="CM" element="C" mass="12.0108"/>
-  <Type name="1856" class="C" element="C" mass="12.0108"/>
-  <Type name="1857" class="O" element="O" mass="15.9994"/>
-  <Type name="918" class="CT" element="C" mass="12.0108"/>
-  <Type name="915" class="CT" element="C" mass="12.0108"/>
-  <Type name="917" class="S" element="S" mass="32.0655"/>
-  <Type name="911" class="CT" element="C" mass="12.0108"/>
-  <Type name="913" class="CT" element="C" mass="12.0108"/>
-  <Type name="1933" class="CT" element="C" mass="12.0108"/>
-  <Type name="1932" class="OS" element="O" mass="15.9994"/>
-  <Type name="1930" class="CT" element="C" mass="12.0108"/>
-  <Type name="1936" class="CM" element="C" mass="12.0108"/>
-  <Type name="1935" class="N*" element="N" mass="14.0067"/>
-  <Type name="1938" class="CM" element="C" mass="12.0108"/>
-  <Type name="847" class="O" element="O" mass="15.9994"/>
-  <Type name="846" class="C" element="C" mass="12.0108"/>
-  <Type name="844" class="CW" element="C" mass="12.0108"/>
-  <Type name="842" class="NA" element="N" mass="14.0067"/>
-  <Type name="840" class="CR" element="C" mass="12.0108"/>
-  <Type name="848" class="N3" element="N" mass="14.0067"/>
-  <Type name="1587" class="NC" element="N" mass="14.0067"/>
-  <Type name="1739" class="CT" element="C" mass="12.0108"/>
-  <Type name="1738" class="CB" element="C" mass="12.0108"/>
-  <Type name="1731" class="O" element="O" mass="15.9994"/>
-  <Type name="1730" class="C" element="C" mass="12.0108"/>
-  <Type name="1732" class="NA" element="N" mass="14.0067"/>
-  <Type name="662" class="CA" element="C" mass="12.0108"/>
-  <Type name="1734" class="CA" element="C" mass="12.0108"/>
-  <Type name="1737" class="NC" element="N" mass="14.0067"/>
-  <Type name="753" class="N3" element="N" mass="14.0067"/>
-  <Type name="752" class="O" element="O" mass="15.9994"/>
-  <Type name="751" class="C" element="C" mass="12.0108"/>
-  <Type name="757" class="CT" element="C" mass="12.0108"/>
-  <Type name="755" class="CT" element="C" mass="12.0108"/>
-  <Type name="759" class="C6" element="C" mass="12.0108"/>
-  <Type name="506" class="CW" element="C" mass="12.0108"/>
-  <Type name="1596" class="OH" element="O" mass="15.9994"/>
-  <Type name="1591" class="CB" element="C" mass="12.0108"/>
-  <Type name="1590" class="NC" element="N" mass="14.0067"/>
-  <Type name="1033" class="OS" element="O" mass="15.9994"/>
-  <Type name="504" class="NA" element="N" mass="14.0067"/>
-  <Type name="1024" class="CT" element="C" mass="12.0108"/>
-  <Type name="1031" class="O2" element="O" mass="15.9994"/>
-  <Type name="1020" class="CT" element="C" mass="12.0108"/>
-  <Type name="1022" class="CT" element="C" mass="12.0108"/>
-  <Type name="1036" class="CT" element="C" mass="12.0108"/>
-  <Type name="1029" class="O" element="O" mass="15.9994"/>
-  <Type name="1028" class="C" element="C" mass="12.0108"/>
-  <Type name="1034" class="CT" element="C" mass="12.0108"/>
-  <Type name="605" class="CA" element="C" mass="12.0108"/>
-  <Type name="607" class="C" element="C" mass="12.0108"/>
-  <Type name="601" class="CA" element="C" mass="12.0108"/>
-  <Type name="603" class="CA" element="C" mass="12.0108"/>
-  <Type name="1205" class="OS" element="O" mass="15.9994"/>
-  <Type name="1206" class="CT" element="C" mass="12.0108"/>
-  <Type name="609" class="O2" element="O" mass="15.9994"/>
-  <Type name="1200" class="OH" element="O" mass="15.9994"/>
-  <Type name="1203" class="CT" element="C" mass="12.0108"/>
-  <Type name="1211" class="CM" element="C" mass="12.0108"/>
-  <Type name="635" class="CT" element="C" mass="12.0108"/>
-  <Type name="1214" class="N2" element="N" mass="14.0067"/>
-  <Type name="1111" class="CT" element="C" mass="12.0108"/>
-  <Type name="1110" class="CB" element="C" mass="12.0108"/>
-  <Type name="1113" class="CT" element="C" mass="12.0108"/>
-  <Type name="1115" class="OS" element="O" mass="15.9994"/>
-  <Type name="1117" class="OH" element="O" mass="15.9994"/>
-  <Type name="464" class="C" element="C" mass="12.0108"/>
-  <Type name="1118" class="CT" element="C" mass="12.0108"/>
-  <Type name="467" class="C" element="C" mass="12.0108"/>
-  <Type name="1448" class="CT" element="C" mass="12.0108"/>
-  <Type name="466" class="O2" element="O" mass="15.9994"/>
-  <Type name="1357" class="CA" element="C" mass="12.0108"/>
-  <Type name="460" class="CT" element="C" mass="12.0108"/>
-  <Type name="1355" class="NA" element="N" mass="14.0067"/>
-  <Type name="489" class="CV" element="C" mass="12.0108"/>
-  <Type name="488" class="NB" element="N" mass="14.0067"/>
-  <Type name="486" class="CR" element="C" mass="12.0108"/>
-  <Type name="1354" class="O" element="O" mass="15.9994"/>
-  <Type name="483" class="CC" element="C" mass="12.0108"/>
-  <Type name="481" class="CT" element="C" mass="12.0108"/>
-  <Type name="199" class="O" element="O" mass="15.9994"/>
-  <Type name="198" class="C" element="C" mass="12.0108"/>
-  <Type name="194" class="CT" element="C" mass="12.0108"/>
-  <Type name="196" class="CT" element="C" mass="12.0108"/>
-  <Type name="190" class="CT" element="C" mass="12.0108"/>
-  <Type name="192" class="C3" element="C" mass="12.0108"/>
-  <Type name="1455" class="CT" element="C" mass="12.0108"/>
-  <Type name="1457" class="OS" element="O" mass="15.9994"/>
-  <Type name="1450" class="OS" element="O" mass="15.9994"/>
-  <Type name="1452" class="OH" element="O" mass="15.9994"/>
-  <Type name="1453" class="CT" element="C" mass="12.0108"/>
-  <Type name="903" class="CT" element="C" mass="12.0108"/>
-  <Type name="901" class="CT" element="C" mass="12.0108"/>
-  <Type name="907" class="C" element="C" mass="12.0108"/>
-  <Type name="905" class="N3" element="N" mass="14.0067"/>
-  <Type name="1843" class="OS" element="O" mass="15.9994"/>
-  <Type name="1511" class="O2" element="O" mass="15.9994"/>
-  <Type name="908" class="O" element="O" mass="15.9994"/>
-  <Type name="909" class="N3" element="N" mass="14.0067"/>
-  <Type name="1846" class="CT" element="C" mass="12.0108"/>
-  <Type name="1844" class="CT" element="C" mass="12.0108"/>
-  <Type name="1908" class="N*" element="N" mass="14.0067"/>
-  <Type name="1909" class="CM" element="C" mass="12.0108"/>
-  <Type name="1906" class="CT" element="C" mass="12.0108"/>
-  <Type name="1905" class="OS" element="O" mass="15.9994"/>
-  <Type name="1903" class="CT" element="C" mass="12.0108"/>
-  <Type name="1900" class="OH" element="O" mass="15.9994"/>
-  <Type name="1901" class="CT" element="C" mass="12.0108"/>
-  <Type name="854" class="CC" element="C" mass="12.0108"/>
-  <Type name="855" class="NA" element="N" mass="14.0067"/>
-  <Type name="857" class="CR" element="C" mass="12.0108"/>
-  <Type name="850" class="CT" element="C" mass="12.0108"/>
-  <Type name="852" class="CT" element="C" mass="12.0108"/>
-  <Type name="859" class="NA" element="N" mass="14.0067"/>
-  <Type name="6" class="C" element="C" mass="12.0108"/>
-  <Type name="740" class="O" element="O" mass="15.9994"/>
-  <Type name="741" class="N3" element="N" mass="14.0067"/>
-  <Type name="743" class="CT" element="C" mass="12.0108"/>
-  <Type name="745" class="CT" element="C" mass="12.0108"/>
-  <Type name="747" class="C5" element="C" mass="12.0108"/>
-  <Type name="748" class="O" element="O" mass="15.9994"/>
-  <Type name="749" class="N" element="N" mass="14.0067"/>
-  <Type name="1798" class="N2" element="N" mass="14.0067"/>
-  <Type name="1050" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1052" class="NC" element="N" mass="14.0067"/>
-  <Type name="1053" class="CB" element="C" mass="12.0108"/>
-  <Type name="1054" class="CT" element="C" mass="12.0108"/>
-  <Type name="1056" class="CT" element="C" mass="12.0108"/>
-  <Type name="1058" class="OS" element="O" mass="15.9994"/>
-  <Type name="1059" class="P" element="P" mass="30.9738"/>
-  <Type name="1696" class="CM" element="C" mass="12.0108"/>
-  <Type name="1695" class="N*" element="N" mass="14.0067"/>
-  <Type name="1692" class="OS" element="O" mass="15.9994"/>
-  <Type name="1693" class="CT" element="C" mass="12.0108"/>
-  <Type name="1690" class="CT" element="C" mass="12.0108"/>
-  <Type name="1791" class="NB" element="N" mass="14.0067"/>
-  <Type name="1698" class="CM" element="C" mass="12.0108"/>
-  <Type name="1279" class="OS" element="O" mass="15.9994"/>
-  <Type name="619" class="C" element="C" mass="12.0108"/>
-  <Type name="613" class="CT" element="C" mass="12.0108"/>
-  <Type name="610" class="N" element="N" mass="14.0067"/>
-  <Type name="611" class="CT" element="C" mass="12.0108"/>
-  <Type name="617" class="CT" element="C" mass="12.0108"/>
-  <Type name="615" class="CT" element="C" mass="12.0108"/>
-  <Type name="1795" class="NA" element="N" mass="14.0067"/>
-  <Type name="1794" class="O" element="O" mass="15.9994"/>
-  <Type name="1472" class="CT" element="C" mass="12.0108"/>
-  <Type name="1470" class="C" element="C" mass="12.0108"/>
-  <Type name="1471" class="O" element="O" mass="15.9994"/>
-  <Type name="1476" class="OH" element="O" mass="15.9994"/>
-  <Type name="1474" class="CT" element="C" mass="12.0108"/>
-  <Type name="1478" class="P" element="P" mass="30.9738"/>
-  <Type name="1479" class="O2" element="O" mass="15.9994"/>
-  <Type name="1304" class="CB" element="C" mass="12.0108"/>
-  <Type name="1305" class="CT" element="C" mass="12.0108"/>
-  <Type name="1307" class="CT" element="C" mass="12.0108"/>
-  <Type name="1300" class="CA" element="C" mass="12.0108"/>
-  <Type name="1301" class="N2" element="N" mass="14.0067"/>
-  <Type name="1303" class="NC" element="N" mass="14.0067"/>
-  <Type name="1497" class="NC" element="N" mass="14.0067"/>
-  <Type name="1309" class="OH" element="O" mass="15.9994"/>
-  <Type name="498" class="CT" element="C" mass="12.0108"/>
-  <Type name="494" class="N" element="N" mass="14.0067"/>
-  <Type name="496" class="CT" element="C" mass="12.0108"/>
-  <Type name="491" class="C" element="C" mass="12.0108"/>
-  <Type name="492" class="O2" element="O" mass="15.9994"/>
-  <Type name="493" class="O2" element="O" mass="15.9994"/>
-  <Type name="25" class="C" element="C" mass="12.0108"/>
-  <Type name="26" class="O" element="O" mass="15.9994"/>
-  <Type name="27" class="N" element="N" mass="14.0067"/>
-  <Type name="20" class="CA" element="C" mass="12.0108"/>
-  <Type name="21" class="N2" element="N" mass="14.0067"/>
-  <Type name="23" class="N2" element="N" mass="14.0067"/>
-  <Type name="29" class="CT" element="C" mass="12.0108"/>
-  <Type name="1703" class="NC" element="N" mass="14.0067"/>
-  <Type name="1875" class="CT" element="C" mass="12.0108"/>
-  <Type name="7" class="O" element="O" mass="15.9994"/>
-  <Type name="1087" class="OH" element="O" mass="15.9994"/>
-  <Type name="1085" class="CT" element="C" mass="12.0108"/>
-  <Type name="1877" class="OS" element="O" mass="15.9994"/>
-  <Type name="1872" class="OS" element="O" mass="15.9994"/>
-  <Type name="1873" class="CT" element="C" mass="12.0108"/>
-  <Type name="1870" class="O2" element="O" mass="15.9994"/>
-  <Type name="1871" class="O2" element="O" mass="15.9994"/>
-  <Type name="1083" class="CT" element="C" mass="12.0108"/>
-  <Type name="1878" class="CT" element="C" mass="12.0108"/>
-  <Type name="1082" class="CB" element="C" mass="12.0108"/>
-  <Type name="977" class="CT" element="C" mass="12.0108"/>
-  <Type name="975" class="N3" element="N" mass="14.0067"/>
-  <Type name="974" class="O" element="O" mass="15.9994"/>
-  <Type name="973" class="C" element="C" mass="12.0108"/>
-  <Type name="1081" class="NC" element="N" mass="14.0067"/>
-  <Type name="971" class="OH" element="O" mass="15.9994"/>
-  <Type name="979" class="CT" element="C" mass="12.0108"/>
-  <Type name="182" class="CW" element="C" mass="12.0108"/>
-  <Type name="180" class="NA" element="N" mass="14.0067"/>
-  <Type name="186" class="N" element="N" mass="14.0067"/>
-  <Type name="184" class="C" element="C" mass="12.0108"/>
-  <Type name="185" class="O" element="O" mass="15.9994"/>
-  <Type name="188" class="CT" element="C" mass="12.0108"/>
-  <Type name="1559" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1919" class="CT" element="C" mass="12.0108"/>
-  <Type name="1918" class="O" element="O" mass="15.9994"/>
-  <Type name="1464" class="CT" element="C" mass="12.0108"/>
-  <Type name="1911" class="CM" element="C" mass="12.0108"/>
-  <Type name="1913" class="C" element="C" mass="12.0108"/>
-  <Type name="1915" class="NA" element="N" mass="14.0067"/>
-  <Type name="1914" class="O" element="O" mass="15.9994"/>
-  <Type name="1917" class="C" element="C" mass="12.0108"/>
-  <Type name="869" class="CT" element="C" mass="12.0108"/>
-  <Type name="861" class="CW" element="C" mass="12.0108"/>
-  <Type name="863" class="C" element="C" mass="12.0108"/>
-  <Type name="865" class="N3" element="N" mass="14.0067"/>
-  <Type name="864" class="O" element="O" mass="15.9994"/>
-  <Type name="867" class="CT" element="C" mass="12.0108"/>
-  <Type name="883" class="CT" element="C" mass="12.0108"/>
-  <Type name="881" class="CT" element="C" mass="12.0108"/>
-  <Type name="887" class="CT" element="C" mass="12.0108"/>
-  <Type name="885" class="C4" element="C" mass="12.0108"/>
-  <Type name="889" class="CT" element="C" mass="12.0108"/>
-  <Type name="774" class="N3" element="N" mass="14.0067"/>
-  <Type name="776" class="CT" element="C" mass="12.0108"/>
-  <Type name="770" class="SH" element="S" mass="32.0655"/>
-  <Type name="773" class="O" element="O" mass="15.9994"/>
-  <Type name="772" class="C" element="C" mass="12.0108"/>
-  <Type name="778" class="CT" element="C" mass="12.0108"/>
-  <Type name="77" class="SH" element="S" mass="32.0655"/>
-  <Type name="75" class="CT" element="C" mass="12.0108"/>
-  <Type name="73" class="CT" element="C" mass="12.0108"/>
-  <Type name="71" class="N" element="N" mass="14.0067"/>
   <Type name="70" class="O" element="O" mass="15.9994"/>
+  <Type name="71" class="N" element="N" mass="14.0067"/>
+  <Type name="73" class="CT" element="C" mass="12.0108"/>
+  <Type name="75" class="CT" element="C" mass="12.0108"/>
+  <Type name="77" class="SH" element="S" mass="32.0655"/>
   <Type name="79" class="C" element="C" mass="12.0108"/>
-  <Type name="1042" class="CK" element="C" mass="12.0108"/>
-  <Type name="1041" class="N*" element="N" mass="14.0067"/>
-  <Type name="1047" class="N2" element="N" mass="14.0067"/>
-  <Type name="1046" class="CA" element="C" mass="12.0108"/>
-  <Type name="1045" class="CB" element="C" mass="12.0108"/>
-  <Type name="1044" class="NB" element="N" mass="14.0067"/>
-  <Type name="1049" class="NC" element="N" mass="14.0067"/>
-  <Type name="1681" class="CT" element="C" mass="12.0108"/>
-  <Type name="1683" class="OH" element="O" mass="15.9994"/>
-  <Type name="1685" class="OS" element="O" mass="15.9994"/>
-  <Type name="1687" class="OH" element="O" mass="15.9994"/>
-  <Type name="1688" class="CT" element="C" mass="12.0108"/>
-  <Type name="1268" class="NA" element="N" mass="14.0067"/>
-  <Type name="669" class="O2" element="O" mass="15.9994"/>
-  <Type name="668" class="O2" element="O" mass="15.9994"/>
-  <Type name="667" class="C" element="C" mass="12.0108"/>
-  <Type name="1262" class="CK" element="C" mass="12.0108"/>
-  <Type name="664" class="CA" element="C" mass="12.0108"/>
-  <Type name="1267" class="O" element="O" mass="15.9994"/>
-  <Type name="1266" class="C" element="C" mass="12.0108"/>
-  <Type name="1265" class="CB" element="C" mass="12.0108"/>
-  <Type name="1264" class="NB" element="N" mass="14.0067"/>
-  <Type name="1468" class="NA" element="N" mass="14.0067"/>
-  <Type name="1018" class="N3" element="N" mass="14.0067"/>
-  <Type name="1467" class="O" element="O" mass="15.9994"/>
-  <Type name="1466" class="C" element="C" mass="12.0108"/>
-  <Type name="1461" class="CM" element="C" mass="12.0108"/>
-  <Type name="1460" class="N*" element="N" mass="14.0067"/>
-  <Type name="1463" class="CM" element="C" mass="12.0108"/>
-  <Type name="1317" class="OS" element="O" mass="15.9994"/>
-  <Type name="1315" class="CT" element="C" mass="12.0108"/>
-  <Type name="1313" class="CT" element="C" mass="12.0108"/>
-  <Type name="1312" class="OH" element="O" mass="15.9994"/>
-  <Type name="1318" class="CT" element="C" mass="12.0108"/>
-  <Type name="1010" class="OH" element="O" mass="15.9994"/>
-  <Type name="318" class="CW" element="C" mass="12.0108"/>
-  <Type name="313" class="CT" element="C" mass="12.0108"/>
-  <Type name="311" class="N" element="N" mass="14.0067"/>
-  <Type name="310" class="O" element="O" mass="15.9994"/>
-  <Type name="317" class="C*" element="C" mass="12.0108"/>
-  <Type name="315" class="CT" element="C" mass="12.0108"/>
-  <Type name="1334" class="CT" element="C" mass="12.0108"/>
-  <Type name="1336" class="CT" element="C" mass="12.0108"/>
-  <Type name="1330" class="N2" element="N" mass="14.0067"/>
-  <Type name="1333" class="CB" element="C" mass="12.0108"/>
-  <Type name="1332" class="NC" element="N" mass="14.0067"/>
-  <Type name="630" class="C" element="C" mass="12.0108"/>
-  <Type name="631" class="O2" element="O" mass="15.9994"/>
-  <Type name="1521" class="CK" element="C" mass="12.0108"/>
-  <Type name="1861" class="O" element="O" mass="15.9994"/>
-  <Type name="1860" class="C" element="C" mass="12.0108"/>
-  <Type name="1862" class="CT" element="C" mass="12.0108"/>
-  <Type name="1864" class="CT" element="C" mass="12.0108"/>
-  <Type name="1866" class="OH" element="O" mass="15.9994"/>
-  <Type name="1869" class="P" element="P" mass="30.9738"/>
-  <Type name="1868" class="OS" element="O" mass="15.9994"/>
-  <Type name="965" class="CT" element="C" mass="12.0108"/>
-  <Type name="967" class="CT" element="C" mass="12.0108"/>
-  <Type name="961" class="C" element="C" mass="12.0108"/>
-  <Type name="962" class="O" element="O" mass="15.9994"/>
-  <Type name="963" class="N3" element="N" mass="14.0067"/>
-  <Type name="969" class="CT" element="C" mass="12.0108"/>
-  <Type name="1241" class="NC" element="N" mass="14.0067"/>
-  <Type name="878" class="O" element="O" mass="15.9994"/>
-  <Type name="877" class="C" element="C" mass="12.0108"/>
-  <Type name="875" class="CT" element="C" mass="12.0108"/>
-  <Type name="1243" class="O" element="O" mass="15.9994"/>
-  <Type name="871" class="CT" element="C" mass="12.0108"/>
-  <Type name="1242" class="C" element="C" mass="12.0108"/>
-  <Type name="1244" class="CT" element="C" mass="12.0108"/>
-  <Type name="891" class="C" element="C" mass="12.0108"/>
-  <Type name="892" class="O" element="O" mass="15.9994"/>
-  <Type name="893" class="N3" element="N" mass="14.0067"/>
-  <Type name="897" class="CT" element="C" mass="12.0108"/>
-  <Type name="899" class="CT" element="C" mass="12.0108"/>
-  <Type name="646" class="N" element="N" mass="14.0067"/>
-  <Type name="648" class="CT" element="C" mass="12.0108"/>
-  <Type name="1537" class="OH" element="O" mass="15.9994"/>
-  <Type name="1788" class="N*" element="N" mass="14.0067"/>
-  <Type name="1789" class="CK" element="C" mass="12.0108"/>
-  <Type name="768" class="CT" element="C" mass="12.0108"/>
-  <Type name="762" class="C" element="C" mass="12.0108"/>
-  <Type name="763" class="O" element="O" mass="15.9994"/>
-  <Type name="760" class="O2" element="O" mass="15.9994"/>
-  <Type name="761" class="O2" element="O" mass="15.9994"/>
-  <Type name="766" class="CT" element="C" mass="12.0108"/>
-  <Type name="764" class="N3" element="N" mass="14.0067"/>
-  <Type name="1078" class="NC" element="N" mass="14.0067"/>
-  <Type name="1079" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1076" class="N2" element="N" mass="14.0067"/>
-  <Type name="1074" class="CB" element="C" mass="12.0108"/>
-  <Type name="1075" class="CA" element="C" mass="12.0108"/>
-  <Type name="1073" class="NB" element="N" mass="14.0067"/>
-  <Type name="1070" class="N*" element="N" mass="14.0067"/>
-  <Type name="1071" class="CK" element="C" mass="12.0108"/>
-  <Type name="1678" class="O" element="O" mass="15.9994"/>
-  <Type name="1561" class="NC" element="N" mass="14.0067"/>
-  <Type name="1674" class="N2" element="N" mass="14.0067"/>
-  <Type name="1676" class="NC" element="N" mass="14.0067"/>
-  <Type name="1677" class="C" element="C" mass="12.0108"/>
-  <Type name="1671" class="CM" element="C" mass="12.0108"/>
-  <Type name="1673" class="CA" element="C" mass="12.0108"/>
-  <Type name="1095" class="OS" element="O" mass="15.9994"/>
-  <Type name="1096" class="CT" element="C" mass="12.0108"/>
-  <Type name="1090" class="OH" element="O" mass="15.9994"/>
-  <Type name="1091" class="CT" element="C" mass="12.0108"/>
-  <Type name="1093" class="CT" element="C" mass="12.0108"/>
-  <Type name="674" class="CT" element="C" mass="12.0108"/>
-  <Type name="676" class="CA" element="C" mass="12.0108"/>
-  <Type name="677" class="CA" element="C" mass="12.0108"/>
-  <Type name="1098" class="N*" element="N" mass="14.0067"/>
-  <Type name="1099" class="CK" element="C" mass="12.0108"/>
-  <Type name="672" class="CT" element="C" mass="12.0108"/>
-  <Type name="1533" class="CT" element="C" mass="12.0108"/>
-  <Type name="1418" class="O" element="O" mass="15.9994"/>
-  <Type name="1419" class="CT" element="C" mass="12.0108"/>
-  <Type name="1410" class="CM" element="C" mass="12.0108"/>
-  <Type name="1411" class="CT" element="C" mass="12.0108"/>
-  <Type name="1413" class="C" element="C" mass="12.0108"/>
-  <Type name="1414" class="O" element="O" mass="15.9994"/>
-  <Type name="1415" class="NA" element="N" mass="14.0067"/>
-  <Type name="1417" class="C" element="C" mass="12.0108"/>
-  <Type name="1323" class="NB" element="N" mass="14.0067"/>
-  <Type name="1320" class="N*" element="N" mass="14.0067"/>
-  <Type name="1321" class="CK" element="C" mass="12.0108"/>
-  <Type name="1326" class="O" element="O" mass="15.9994"/>
-  <Type name="1327" class="NA" element="N" mass="14.0067"/>
-  <Type name="1324" class="CB" element="C" mass="12.0108"/>
-  <Type name="1325" class="C" element="C" mass="12.0108"/>
-  <Type name="1329" class="CA" element="C" mass="12.0108"/>
-  <Type name="1531" class="NC" element="N" mass="14.0067"/>
-  <Type name="1256" class="CT" element="C" mass="12.0108"/>
-  <Type name="1254" class="CT" element="C" mass="12.0108"/>
-  <Type name="1252" class="O2" element="O" mass="15.9994"/>
-  <Type name="1253" class="OS" element="O" mass="15.9994"/>
-  <Type name="1250" class="P" element="P" mass="30.9738"/>
-  <Type name="1251" class="O2" element="O" mass="15.9994"/>
-  <Type name="1528" class="NC" element="N" mass="14.0067"/>
-  <Type name="1529" class="CQ" element="C" mass="12.0108"/>
-  <Type name="1258" class="OS" element="O" mass="15.9994"/>
-  <Type name="1259" class="CT" element="C" mass="12.0108"/>
-  <Type name="309" class="C" element="C" mass="12.0108"/>
-  <Type name="301" class="CT" element="C" mass="12.0108"/>
-  <Type name="303" class="CT" element="C" mass="12.0108"/>
-  <Type name="305" class="CT" element="C" mass="12.0108"/>
-  <Type name="307" class="OH" element="O" mass="15.9994"/>
-  <Type name="1792" class="CB" element="C" mass="12.0108"/>
-  <Type name="470" class="N" element="N" mass="14.0067"/>
-  <Type name="1895" class="OH" element="O" mass="15.9994"/>
-  <Type name="1890" class="O" element="O" mass="15.9994"/>
-  <Type name="476" class="O2" element="O" mass="15.9994"/>
-  <Type name="1893" class="CT" element="C" mass="12.0108"/>
-  <Type name="959" class="OH" element="O" mass="15.9994"/>
-  <Type name="951" class="C" element="C" mass="12.0108"/>
-  <Type name="953" class="N3" element="N" mass="14.0067"/>
-  <Type name="952" class="O" element="O" mass="15.9994"/>
-  <Type name="955" class="CT" element="C" mass="12.0108"/>
-  <Type name="957" class="CT" element="C" mass="12.0108"/>
-  <Type name="1442" class="NA" element="N" mass="14.0067"/>
-  <Type name="477" class="N" element="N" mass="14.0067"/>
-  <Type name="1440" class="C" element="C" mass="12.0108"/>
-  <Type name="666" class="CB" element="C" mass="12.0108"/>
-  <Type name="1261" class="N*" element="N" mass="14.0067"/>
-  <Type name="718" class="CT" element="C" mass="12.0108"/>
-  <Type name="716" class="CT" element="C" mass="12.0108"/>
-  <Type name="714" class="N3" element="N" mass="14.0067"/>
-  <Type name="713" class="O" element="O" mass="15.9994"/>
-  <Type name="712" class="C" element="C" mass="12.0108"/>
-  <Type name="711" class="CT" element="C" mass="12.0108"/>
-  <Type name="660" class="CA" element="C" mass="12.0108"/>
-  <Type name="1068" class="CT" element="C" mass="12.0108"/>
-  <Type name="1061" class="O2" element="O" mass="15.9994"/>
-  <Type name="1060" class="O2" element="O" mass="15.9994"/>
-  <Type name="1063" class="CT" element="C" mass="12.0108"/>
-  <Type name="1062" class="OS" element="O" mass="15.9994"/>
-  <Type name="1065" class="CT" element="C" mass="12.0108"/>
-  <Type name="1067" class="OS" element="O" mass="15.9994"/>
-  <Type name="1669" class="CM" element="C" mass="12.0108"/>
-  <Type name="1668" class="N*" element="N" mass="14.0067"/>
-  <Type name="1666" class="CT" element="C" mass="12.0108"/>
-  <Type name="1665" class="OS" element="O" mass="15.9994"/>
-  <Type name="1663" class="CT" element="C" mass="12.0108"/>
-  <Type name="1661" class="CT" element="C" mass="12.0108"/>
-  <Type name="1660" class="OH" element="O" mass="15.9994"/>
-  <Type name="590" class="N" element="N" mass="14.0067"/>
-  <Type name="592" class="CT" element="C" mass="12.0108"/>
-  <Type name="594" class="CT" element="C" mass="12.0108"/>
-  <Type name="597" class="CA" element="C" mass="12.0108"/>
-  <Type name="596" class="CA" element="C" mass="12.0108"/>
-  <Type name="599" class="CA" element="C" mass="12.0108"/>
-  <Type name="1408" class="CM" element="C" mass="12.0108"/>
-  <Type name="1402" class="CT" element="C" mass="12.0108"/>
-  <Type name="1400" class="CT" element="C" mass="12.0108"/>
-  <Type name="1407" class="N*" element="N" mass="14.0067"/>
-  <Type name="1405" class="CT" element="C" mass="12.0108"/>
-  <Type name="1404" class="OS" element="O" mass="15.9994"/>
-  <Type name="449" class="C" element="C" mass="12.0108"/>
-  <Type name="1338" class="OS" element="O" mass="15.9994"/>
-  <Type name="1547" class="OS" element="O" mass="15.9994"/>
-  <Type name="443" class="CT" element="C" mass="12.0108"/>
-  <Type name="441" class="N" element="N" mass="14.0067"/>
-  <Type name="440" class="O2" element="O" mass="15.9994"/>
-  <Type name="447" class="CT" element="C" mass="12.0108"/>
-  <Type name="445" class="CT" element="C" mass="12.0108"/>
-  <Type name="1520" class="N*" element="N" mass="14.0067"/>
-  <Type name="1542" class="OH" element="O" mass="15.9994"/>
-  <Type name="1543" class="CT" element="C" mass="12.0108"/>
-  <Type name="39" class="N" element="N" mass="14.0067"/>
-  <Type name="38" class="O" element="O" mass="15.9994"/>
-  <Type name="33" class="C" element="C" mass="12.0108"/>
-  <Type name="31" class="CT" element="C" mass="12.0108"/>
-  <Type name="37" class="C" element="C" mass="12.0108"/>
-  <Type name="35" class="OH" element="O" mass="15.9994"/>
-  <Type name="34" class="O" element="O" mass="15.9994"/>
-  <Type name="641" class="OH" element="O" mass="15.9994"/>
-  <Type name="643" class="C" element="C" mass="12.0108"/>
-  <Type name="645" class="O2" element="O" mass="15.9994"/>
-  <Type name="644" class="O2" element="O" mass="15.9994"/>
-  <Type name="1246" class="CT" element="C" mass="12.0108"/>
-  <Type name="1248" class="OH" element="O" mass="15.9994"/>
-  <Type name="1539" class="OH" element="O" mass="15.9994"/>
-  <Type name="338" class="CT" element="C" mass="12.0108"/>
-  <Type name="334" class="N" element="N" mass="14.0067"/>
-  <Type name="336" class="CT" element="C" mass="12.0108"/>
-  <Type name="331" class="CB" element="C" mass="12.0108"/>
-  <Type name="333" class="O" element="O" mass="15.9994"/>
-  <Type name="332" class="C" element="C" mass="12.0108"/>
-  <Type name="1026" class="CT" element="C" mass="12.0108"/>
-  <Type name="8" class="N" element="N" mass="14.0067"/>
-  <Type name="1889" class="C" element="C" mass="12.0108"/>
-  <Type name="1887" class="NA" element="N" mass="14.0067"/>
-  <Type name="1886" class="O" element="O" mass="15.9994"/>
-  <Type name="1885" class="C" element="C" mass="12.0108"/>
-  <Type name="1883" class="CM" element="C" mass="12.0108"/>
-  <Type name="1881" class="CM" element="C" mass="12.0108"/>
-  <Type name="1880" class="N*" element="N" mass="14.0067"/>
-  <Type name="949" class="CT" element="C" mass="12.0108"/>
-  <Type name="947" class="CT" element="C" mass="12.0108"/>
-  <Type name="945" class="CT" element="C" mass="12.0108"/>
-  <Type name="943" class="CT" element="C" mass="12.0108"/>
-  <Type name="940" class="O" element="O" mass="15.9994"/>
-  <Type name="941" class="N3" element="N" mass="14.0067"/>
-  <Type name="133" class="CT" element="C" mass="12.0108"/>
-  <Type name="131" class="N" element="N" mass="14.0067"/>
-  <Type name="130" class="O" element="O" mass="15.9994"/>
-  <Type name="137" class="N" element="N" mass="14.0067"/>
-  <Type name="136" class="O" element="O" mass="15.9994"/>
-  <Type name="135" class="C" element="C" mass="12.0108"/>
-  <Type name="139" class="CT" element="C" mass="12.0108"/>
-  <Type name="1793" class="C" element="C" mass="12.0108"/>
-  <Type name="708" class="CT" element="C" mass="12.0108"/>
-  <Type name="704" class="N" element="N" mass="14.0067"/>
-  <Type name="706" class="N" element="N" mass="14.0067"/>
-  <Type name="701" class="C" element="C" mass="12.0108"/>
-  <Type name="702" class="O2" element="O" mass="15.9994"/>
-  <Type name="703" class="O2" element="O" mass="15.9994"/>
-  <Type name="88" class="C" element="C" mass="12.0108"/>
-  <Type name="89" class="O" element="O" mass="15.9994"/>
-  <Type name="83" class="CT" element="C" mass="12.0108"/>
   <Type name="80" class="O" element="O" mass="15.9994"/>
   <Type name="81" class="N" element="N" mass="14.0067"/>
-  <Type name="87" class="S" element="S" mass="32.0655"/>
+  <Type name="83" class="CT" element="C" mass="12.0108"/>
   <Type name="85" class="CT" element="C" mass="12.0108"/>
-  <Type name="1650" class="O" element="O" mass="15.9994"/>
-  <Type name="1651" class="CT" element="C" mass="12.0108"/>
-  <Type name="1657" class="OH" element="O" mass="15.9994"/>
-  <Type name="1389" class="C" element="C" mass="12.0108"/>
-  <Type name="587" class="C" element="C" mass="12.0108"/>
-  <Type name="584" class="S" element="S" mass="32.0655"/>
-  <Type name="585" class="CT" element="C" mass="12.0108"/>
-  <Type name="582" class="CT" element="C" mass="12.0108"/>
-  <Type name="580" class="CT" element="C" mass="12.0108"/>
-  <Type name="588" class="O2" element="O" mass="15.9994"/>
-  <Type name="589" class="O2" element="O" mass="15.9994"/>
-  <Type name="1633" class="CT" element="C" mass="12.0108"/>
-  <Type name="1437" class="CM" element="C" mass="12.0108"/>
-  <Type name="1434" class="N*" element="N" mass="14.0067"/>
-  <Type name="1435" class="CM" element="C" mass="12.0108"/>
-  <Type name="1432" class="CT" element="C" mass="12.0108"/>
-  <Type name="1431" class="OS" element="O" mass="15.9994"/>
-  <Type name="1380" class="CM" element="C" mass="12.0108"/>
-  <Type name="1438" class="CT" element="C" mass="12.0108"/>
-  <Type name="1349" class="CK" element="C" mass="12.0108"/>
-  <Type name="1348" class="N*" element="N" mass="14.0067"/>
-  <Type name="450" class="O" element="O" mass="15.9994"/>
-  <Type name="451" class="N" element="N" mass="14.0067"/>
-  <Type name="1343" class="CT" element="C" mass="12.0108"/>
-  <Type name="1345" class="OS" element="O" mass="15.9994"/>
-  <Type name="456" class="N" element="N" mass="14.0067"/>
-  <Type name="657" class="CN" element="C" mass="12.0108"/>
-  <Type name="655" class="NA" element="N" mass="14.0067"/>
-  <Type name="652" class="C*" element="C" mass="12.0108"/>
-  <Type name="653" class="CW" element="C" mass="12.0108"/>
-  <Type name="650" class="CT" element="C" mass="12.0108"/>
-  <Type name="1508" class="OS" element="O" mass="15.9994"/>
-  <Type name="1509" class="P" element="P" mass="30.9738"/>
-  <Type name="658" class="CA" element="C" mass="12.0108"/>
-  <Type name="1376" class="OS" element="O" mass="15.9994"/>
-  <Type name="322" class="CN" element="C" mass="12.0108"/>
-  <Type name="323" class="CA" element="C" mass="12.0108"/>
-  <Type name="320" class="NA" element="N" mass="14.0067"/>
-  <Type name="327" class="CA" element="C" mass="12.0108"/>
-  <Type name="325" class="CA" element="C" mass="12.0108"/>
-  <Type name="329" class="CA" element="C" mass="12.0108"/>
-  <Type name="1340" class="OH" element="O" mass="15.9994"/>
-  <Type name="1594" class="CT" element="C" mass="12.0108"/>
-  <Type name="1341" class="CT" element="C" mass="12.0108"/>
-  <Type name="1592" class="CT" element="C" mass="12.0108"/>
-  <Type name="1598" class="OH" element="O" mass="15.9994"/>
-  <Type name="995" class="CB" element="C" mass="12.0108"/>
-  <Type name="997" class="O" element="O" mass="15.9994"/>
-  <Type name="996" class="C" element="C" mass="12.0108"/>
-  <Type name="991" class="CA" element="C" mass="12.0108"/>
-  <Type name="993" class="CA" element="C" mass="12.0108"/>
-  <Type name="998" class="N3" element="N" mass="14.0067"/>
+  <Type name="87" class="S" element="S" mass="32.0655"/>
+  <Type name="88" class="C" element="C" mass="12.0108"/>
+  <Type name="89" class="O" element="O" mass="15.9994"/>
+  <Type name="90" class="N" element="N" mass="14.0067"/>
+  <Type name="92" class="CT" element="C" mass="12.0108"/>
+  <Type name="94" class="CT" element="C" mass="12.0108"/>
+  <Type name="96" class="CT" element="C" mass="12.0108"/>
+  <Type name="98" class="C" element="C" mass="12.0108"/>
+  <Type name="99" class="O" element="O" mass="15.9994"/>
+  <Type name="100" class="OH" element="O" mass="15.9994"/>
+  <Type name="102" class="C" element="C" mass="12.0108"/>
+  <Type name="103" class="O" element="O" mass="15.9994"/>
+  <Type name="104" class="N" element="N" mass="14.0067"/>
+  <Type name="106" class="CT" element="C" mass="12.0108"/>
+  <Type name="108" class="CT" element="C" mass="12.0108"/>
+  <Type name="110" class="CT" element="C" mass="12.0108"/>
+  <Type name="112" class="C" element="C" mass="12.0108"/>
+  <Type name="113" class="O" element="O" mass="15.9994"/>
+  <Type name="114" class="N" element="N" mass="14.0067"/>
+  <Type name="116" class="C" element="C" mass="12.0108"/>
+  <Type name="117" class="O" element="O" mass="15.9994"/>
+  <Type name="118" class="N" element="N" mass="14.0067"/>
   <Type name="120" class="CT" element="C" mass="12.0108"/>
   <Type name="122" class="CT" element="C" mass="12.0108"/>
   <Type name="124" class="CT" element="C" mass="12.0108"/>
@@ -1116,177 +84,1539 @@
   <Type name="127" class="O2" element="O" mass="15.9994"/>
   <Type name="128" class="O2" element="O" mass="15.9994"/>
   <Type name="129" class="C" element="C" mass="12.0108"/>
-  <Type name="1748" class="O2" element="O" mass="15.9994"/>
-  <Type name="1749" class="OS" element="O" mass="15.9994"/>
-  <Type name="1645" class="CA" element="C" mass="12.0108"/>
-  <Type name="1646" class="N2" element="N" mass="14.0067"/>
-  <Type name="1641" class="CM" element="C" mass="12.0108"/>
-  <Type name="1640" class="N*" element="N" mass="14.0067"/>
-  <Type name="1643" class="CM" element="C" mass="12.0108"/>
-  <Type name="1649" class="C" element="C" mass="12.0108"/>
-  <Type name="1648" class="NC" element="N" mass="14.0067"/>
-  <Type name="1743" class="OH" element="O" mass="15.9994"/>
-  <Type name="578" class="CT" element="C" mass="12.0108"/>
-  <Type name="573" class="C" element="C" mass="12.0108"/>
-  <Type name="571" class="N3" element="N" mass="14.0067"/>
-  <Type name="576" class="N" element="N" mass="14.0067"/>
-  <Type name="575" class="O2" element="O" mass="15.9994"/>
-  <Type name="574" class="O2" element="O" mass="15.9994"/>
-  <Type name="1209" class="CM" element="C" mass="12.0108"/>
-  <Type name="1208" class="N*" element="N" mass="14.0067"/>
-  <Type name="1421" class="CT" element="C" mass="12.0108"/>
-  <Type name="1423" class="OH" element="O" mass="15.9994"/>
-  <Type name="1427" class="CT" element="C" mass="12.0108"/>
-  <Type name="1426" class="OH" element="O" mass="15.9994"/>
-  <Type name="1429" class="CT" element="C" mass="12.0108"/>
-  <Type name="730" class="CT" element="C" mass="12.0108"/>
-  <Type name="732" class="N2" element="N" mass="14.0067"/>
-  <Type name="735" class="N2" element="N" mass="14.0067"/>
-  <Type name="734" class="CA" element="C" mass="12.0108"/>
-  <Type name="737" class="N2" element="N" mass="14.0067"/>
-  <Type name="739" class="C" element="C" mass="12.0108"/>
-  <Type name="1358" class="N2" element="N" mass="14.0067"/>
-  <Type name="469" class="O2" element="O" mass="15.9994"/>
-  <Type name="468" class="O2" element="O" mass="15.9994"/>
-  <Type name="1353" class="C" element="C" mass="12.0108"/>
-  <Type name="1352" class="CB" element="C" mass="12.0108"/>
-  <Type name="1351" class="NB" element="N" mass="14.0067"/>
-  <Type name="462" class="CT" element="C" mass="12.0108"/>
-  <Type name="1273" class="NC" element="N" mass="14.0067"/>
-  <Type name="1518" class="CT" element="C" mass="12.0108"/>
-  <Type name="1515" class="CT" element="C" mass="12.0108"/>
-  <Type name="1517" class="OS" element="O" mass="15.9994"/>
-  <Type name="1274" class="CB" element="C" mass="12.0108"/>
-  <Type name="1510" class="O2" element="O" mass="15.9994"/>
-  <Type name="1513" class="CT" element="C" mass="12.0108"/>
-  <Type name="1512" class="OS" element="O" mass="15.9994"/>
-  <Type name="1735" class="N2" element="N" mass="14.0067"/>
-  <Type name="1275" class="CT" element="C" mass="12.0108"/>
-  <Type name="356" class="CT" element="C" mass="12.0108"/>
-  <Type name="354" class="N" element="N" mass="14.0067"/>
-  <Type name="353" class="O" element="O" mass="15.9994"/>
-  <Type name="352" class="C" element="C" mass="12.0108"/>
-  <Type name="350" class="CA" element="C" mass="12.0108"/>
-  <Type name="358" class="CT" element="C" mass="12.0108"/>
-  <Type name="1446" class="CT" element="C" mass="12.0108"/>
-  <Type name="1445" class="O" element="O" mass="15.9994"/>
-  <Type name="289" class="N" element="N" mass="14.0067"/>
-  <Type name="288" class="O" element="O" mass="15.9994"/>
-  <Type name="1444" class="C" element="C" mass="12.0108"/>
+  <Type name="130" class="O" element="O" mass="15.9994"/>
+  <Type name="131" class="N" element="N" mass="14.0067"/>
+  <Type name="133" class="CT" element="C" mass="12.0108"/>
+  <Type name="135" class="C" element="C" mass="12.0108"/>
+  <Type name="136" class="O" element="O" mass="15.9994"/>
+  <Type name="137" class="N" element="N" mass="14.0067"/>
+  <Type name="139" class="CT" element="C" mass="12.0108"/>
+  <Type name="141" class="CT" element="C" mass="12.0108"/>
+  <Type name="143" class="CC" element="C" mass="12.0108"/>
+  <Type name="144" class="NA" element="N" mass="14.0067"/>
+  <Type name="146" class="CR" element="C" mass="12.0108"/>
+  <Type name="148" class="NB" element="N" mass="14.0067"/>
+  <Type name="149" class="CV" element="C" mass="12.0108"/>
+  <Type name="151" class="C" element="C" mass="12.0108"/>
+  <Type name="152" class="O" element="O" mass="15.9994"/>
+  <Type name="153" class="N" element="N" mass="14.0067"/>
+  <Type name="155" class="CT" element="C" mass="12.0108"/>
+  <Type name="157" class="CT" element="C" mass="12.0108"/>
+  <Type name="159" class="CC" element="C" mass="12.0108"/>
+  <Type name="160" class="NB" element="N" mass="14.0067"/>
+  <Type name="161" class="CR" element="C" mass="12.0108"/>
+  <Type name="163" class="NA" element="N" mass="14.0067"/>
+  <Type name="165" class="CW" element="C" mass="12.0108"/>
+  <Type name="167" class="C" element="C" mass="12.0108"/>
+  <Type name="168" class="O" element="O" mass="15.9994"/>
+  <Type name="169" class="N" element="N" mass="14.0067"/>
+  <Type name="171" class="CT" element="C" mass="12.0108"/>
+  <Type name="173" class="CT" element="C" mass="12.0108"/>
+  <Type name="175" class="CC" element="C" mass="12.0108"/>
+  <Type name="176" class="NA" element="N" mass="14.0067"/>
+  <Type name="178" class="CR" element="C" mass="12.0108"/>
+  <Type name="180" class="NA" element="N" mass="14.0067"/>
+  <Type name="182" class="CW" element="C" mass="12.0108"/>
+  <Type name="184" class="C" element="C" mass="12.0108"/>
+  <Type name="185" class="O" element="O" mass="15.9994"/>
+  <Type name="186" class="N" element="N" mass="14.0067"/>
+  <Type name="188" class="CT" element="C" mass="12.0108"/>
+  <Type name="190" class="CT" element="C" mass="12.0108"/>
+  <Type name="192" class="C3" element="C" mass="12.0108"/>
+  <Type name="194" class="CT" element="C" mass="12.0108"/>
+  <Type name="196" class="CT" element="C" mass="12.0108"/>
+  <Type name="198" class="C" element="C" mass="12.0108"/>
+  <Type name="199" class="O" element="O" mass="15.9994"/>
+  <Type name="200" class="N" element="N" mass="14.0067"/>
+  <Type name="202" class="CT" element="C" mass="12.0108"/>
+  <Type name="204" class="CT" element="C" mass="12.0108"/>
+  <Type name="206" class="C4" element="C" mass="12.0108"/>
+  <Type name="208" class="CT" element="C" mass="12.0108"/>
+  <Type name="210" class="CT" element="C" mass="12.0108"/>
+  <Type name="212" class="C" element="C" mass="12.0108"/>
+  <Type name="213" class="O" element="O" mass="15.9994"/>
+  <Type name="214" class="N" element="N" mass="14.0067"/>
+  <Type name="216" class="CT" element="C" mass="12.0108"/>
+  <Type name="218" class="CT" element="C" mass="12.0108"/>
+  <Type name="220" class="CT" element="C" mass="12.0108"/>
+  <Type name="222" class="CT" element="C" mass="12.0108"/>
+  <Type name="224" class="CT" element="C" mass="12.0108"/>
+  <Type name="226" class="N3" element="N" mass="14.0067"/>
+  <Type name="228" class="C" element="C" mass="12.0108"/>
+  <Type name="229" class="O" element="O" mass="15.9994"/>
+  <Type name="230" class="N" element="N" mass="14.0067"/>
+  <Type name="232" class="CT" element="C" mass="12.0108"/>
+  <Type name="234" class="CT" element="C" mass="12.0108"/>
+  <Type name="236" class="CT" element="C" mass="12.0108"/>
+  <Type name="238" class="CT" element="C" mass="12.0108"/>
+  <Type name="240" class="CT" element="C" mass="12.0108"/>
+  <Type name="242" class="N3" element="N" mass="14.0067"/>
+  <Type name="244" class="C" element="C" mass="12.0108"/>
+  <Type name="245" class="O" element="O" mass="15.9994"/>
+  <Type name="246" class="N" element="N" mass="14.0067"/>
+  <Type name="248" class="CT" element="C" mass="12.0108"/>
+  <Type name="250" class="CT" element="C" mass="12.0108"/>
+  <Type name="252" class="CT" element="C" mass="12.0108"/>
+  <Type name="254" class="S" element="S" mass="32.0655"/>
+  <Type name="255" class="CT" element="C" mass="12.0108"/>
+  <Type name="257" class="C" element="C" mass="12.0108"/>
+  <Type name="258" class="O" element="O" mass="15.9994"/>
+  <Type name="259" class="N" element="N" mass="14.0067"/>
+  <Type name="261" class="CT" element="C" mass="12.0108"/>
+  <Type name="263" class="CT" element="C" mass="12.0108"/>
+  <Type name="265" class="CA" element="C" mass="12.0108"/>
+  <Type name="266" class="CA" element="C" mass="12.0108"/>
+  <Type name="268" class="CA" element="C" mass="12.0108"/>
+  <Type name="270" class="CA" element="C" mass="12.0108"/>
+  <Type name="272" class="CA" element="C" mass="12.0108"/>
+  <Type name="274" class="CA" element="C" mass="12.0108"/>
+  <Type name="276" class="C" element="C" mass="12.0108"/>
+  <Type name="277" class="O" element="O" mass="15.9994"/>
+  <Type name="278" class="N" element="N" mass="14.0067"/>
+  <Type name="279" class="CT" element="C" mass="12.0108"/>
   <Type name="281" class="CT" element="C" mass="12.0108"/>
   <Type name="283" class="CT" element="C" mass="12.0108"/>
   <Type name="285" class="CT" element="C" mass="12.0108"/>
   <Type name="287" class="C" element="C" mass="12.0108"/>
-  <Type name="1441" class="O" element="O" mass="15.9994"/>
-  <Type name="263" class="CT" element="C" mass="12.0108"/>
-  <Type name="261" class="CT" element="C" mass="12.0108"/>
-  <Type name="266" class="CA" element="C" mass="12.0108"/>
-  <Type name="265" class="CA" element="C" mass="12.0108"/>
-  <Type name="268" class="CA" element="C" mass="12.0108"/>
-  <Type name="1562" class="CB" element="C" mass="12.0108"/>
-  <Type name="1563" class="CT" element="C" mass="12.0108"/>
-  <Type name="1565" class="CT" element="C" mass="12.0108"/>
-  <Type name="1567" class="OH" element="O" mass="15.9994"/>
-  <Type name="989" class="CA" element="C" mass="12.0108"/>
-  <Type name="982" class="CW" element="C" mass="12.0108"/>
-  <Type name="981" class="C*" element="C" mass="12.0108"/>
-  <Type name="986" class="CN" element="C" mass="12.0108"/>
-  <Type name="987" class="CA" element="C" mass="12.0108"/>
-  <Type name="984" class="NA" element="N" mass="14.0067"/>
-  <Type name="114" class="N" element="N" mass="14.0067"/>
-  <Type name="117" class="O" element="O" mass="15.9994"/>
-  <Type name="116" class="C" element="C" mass="12.0108"/>
-  <Type name="110" class="CT" element="C" mass="12.0108"/>
-  <Type name="113" class="O" element="O" mass="15.9994"/>
-  <Type name="112" class="C" element="C" mass="12.0108"/>
-  <Type name="118" class="N" element="N" mass="14.0067"/>
-  <Type name="1797" class="CA" element="C" mass="12.0108"/>
-  <Type name="1630" class="O2" element="O" mass="15.9994"/>
-  <Type name="1631" class="O2" element="O" mass="15.9994"/>
-  <Type name="1632" class="OS" element="O" mass="15.9994"/>
+  <Type name="288" class="O" element="O" mass="15.9994"/>
+  <Type name="289" class="N" element="N" mass="14.0067"/>
+  <Type name="291" class="CT" element="C" mass="12.0108"/>
+  <Type name="293" class="CT" element="C" mass="12.0108"/>
+  <Type name="295" class="OH" element="O" mass="15.9994"/>
+  <Type name="297" class="C" element="C" mass="12.0108"/>
+  <Type name="298" class="O" element="O" mass="15.9994"/>
+  <Type name="299" class="N" element="N" mass="14.0067"/>
+  <Type name="301" class="CT" element="C" mass="12.0108"/>
+  <Type name="303" class="CT" element="C" mass="12.0108"/>
+  <Type name="305" class="CT" element="C" mass="12.0108"/>
+  <Type name="307" class="OH" element="O" mass="15.9994"/>
+  <Type name="309" class="C" element="C" mass="12.0108"/>
+  <Type name="310" class="O" element="O" mass="15.9994"/>
+  <Type name="311" class="N" element="N" mass="14.0067"/>
+  <Type name="313" class="CT" element="C" mass="12.0108"/>
+  <Type name="315" class="CT" element="C" mass="12.0108"/>
+  <Type name="317" class="C*" element="C" mass="12.0108"/>
+  <Type name="318" class="CW" element="C" mass="12.0108"/>
+  <Type name="320" class="NA" element="N" mass="14.0067"/>
+  <Type name="322" class="CN" element="C" mass="12.0108"/>
+  <Type name="323" class="CA" element="C" mass="12.0108"/>
+  <Type name="325" class="CA" element="C" mass="12.0108"/>
+  <Type name="327" class="CA" element="C" mass="12.0108"/>
+  <Type name="329" class="CA" element="C" mass="12.0108"/>
+  <Type name="331" class="CB" element="C" mass="12.0108"/>
+  <Type name="332" class="C" element="C" mass="12.0108"/>
+  <Type name="333" class="O" element="O" mass="15.9994"/>
+  <Type name="334" class="N" element="N" mass="14.0067"/>
+  <Type name="336" class="CT" element="C" mass="12.0108"/>
+  <Type name="338" class="CT" element="C" mass="12.0108"/>
+  <Type name="340" class="CA" element="C" mass="12.0108"/>
+  <Type name="341" class="CA" element="C" mass="12.0108"/>
+  <Type name="343" class="CA" element="C" mass="12.0108"/>
+  <Type name="345" class="C" element="C" mass="12.0108"/>
+  <Type name="346" class="OH" element="O" mass="15.9994"/>
+  <Type name="348" class="CA" element="C" mass="12.0108"/>
+  <Type name="350" class="CA" element="C" mass="12.0108"/>
+  <Type name="352" class="C" element="C" mass="12.0108"/>
+  <Type name="353" class="O" element="O" mass="15.9994"/>
+  <Type name="354" class="N" element="N" mass="14.0067"/>
+  <Type name="356" class="CT" element="C" mass="12.0108"/>
+  <Type name="358" class="CT" element="C" mass="12.0108"/>
+  <Type name="360" class="CT" element="C" mass="12.0108"/>
+  <Type name="362" class="CT" element="C" mass="12.0108"/>
+  <Type name="364" class="C" element="C" mass="12.0108"/>
+  <Type name="365" class="O" element="O" mass="15.9994"/>
+  <Type name="366" class="N" element="N" mass="14.0067"/>
+  <Type name="368" class="CT" element="C" mass="12.0108"/>
+  <Type name="370" class="CT" element="C" mass="12.0108"/>
+  <Type name="372" class="C" element="C" mass="12.0108"/>
+  <Type name="373" class="O2" element="O" mass="15.9994"/>
+  <Type name="374" class="O2" element="O" mass="15.9994"/>
+  <Type name="375" class="N" element="N" mass="14.0067"/>
+  <Type name="377" class="CT" element="C" mass="12.0108"/>
+  <Type name="379" class="CT" element="C" mass="12.0108"/>
+  <Type name="381" class="CT" element="C" mass="12.0108"/>
+  <Type name="383" class="CT" element="C" mass="12.0108"/>
+  <Type name="385" class="N2" element="N" mass="14.0067"/>
+  <Type name="387" class="CA" element="C" mass="12.0108"/>
+  <Type name="388" class="N2" element="N" mass="14.0067"/>
+  <Type name="390" class="N2" element="N" mass="14.0067"/>
+  <Type name="392" class="C" element="C" mass="12.0108"/>
+  <Type name="393" class="O2" element="O" mass="15.9994"/>
+  <Type name="394" class="O2" element="O" mass="15.9994"/>
+  <Type name="395" class="N" element="N" mass="14.0067"/>
+  <Type name="397" class="CT" element="C" mass="12.0108"/>
+  <Type name="399" class="CT" element="C" mass="12.0108"/>
+  <Type name="401" class="C5" element="C" mass="12.0108"/>
+  <Type name="402" class="O" element="O" mass="15.9994"/>
+  <Type name="403" class="N" element="N" mass="14.0067"/>
+  <Type name="405" class="C" element="C" mass="12.0108"/>
+  <Type name="406" class="O2" element="O" mass="15.9994"/>
+  <Type name="407" class="O2" element="O" mass="15.9994"/>
+  <Type name="408" class="N" element="N" mass="14.0067"/>
+  <Type name="410" class="CT" element="C" mass="12.0108"/>
+  <Type name="412" class="CT" element="C" mass="12.0108"/>
+  <Type name="414" class="C6" element="C" mass="12.0108"/>
+  <Type name="415" class="O2" element="O" mass="15.9994"/>
+  <Type name="416" class="O2" element="O" mass="15.9994"/>
+  <Type name="417" class="C" element="C" mass="12.0108"/>
+  <Type name="418" class="O2" element="O" mass="15.9994"/>
+  <Type name="419" class="O2" element="O" mass="15.9994"/>
+  <Type name="420" class="N" element="N" mass="14.0067"/>
+  <Type name="422" class="CT" element="C" mass="12.0108"/>
+  <Type name="424" class="CT" element="C" mass="12.0108"/>
+  <Type name="426" class="SH" element="S" mass="32.0655"/>
+  <Type name="428" class="C" element="C" mass="12.0108"/>
+  <Type name="429" class="O2" element="O" mass="15.9994"/>
+  <Type name="430" class="O2" element="O" mass="15.9994"/>
+  <Type name="431" class="N" element="N" mass="14.0067"/>
+  <Type name="433" class="CT" element="C" mass="12.0108"/>
+  <Type name="435" class="CT" element="C" mass="12.0108"/>
+  <Type name="437" class="S" element="S" mass="32.0655"/>
+  <Type name="438" class="C" element="C" mass="12.0108"/>
+  <Type name="439" class="O2" element="O" mass="15.9994"/>
+  <Type name="440" class="O2" element="O" mass="15.9994"/>
+  <Type name="441" class="N" element="N" mass="14.0067"/>
+  <Type name="443" class="CT" element="C" mass="12.0108"/>
+  <Type name="445" class="CT" element="C" mass="12.0108"/>
+  <Type name="447" class="CT" element="C" mass="12.0108"/>
+  <Type name="449" class="C" element="C" mass="12.0108"/>
+  <Type name="450" class="O" element="O" mass="15.9994"/>
+  <Type name="451" class="N" element="N" mass="14.0067"/>
+  <Type name="453" class="C" element="C" mass="12.0108"/>
+  <Type name="454" class="O2" element="O" mass="15.9994"/>
+  <Type name="455" class="O2" element="O" mass="15.9994"/>
+  <Type name="456" class="N" element="N" mass="14.0067"/>
+  <Type name="458" class="CT" element="C" mass="12.0108"/>
+  <Type name="460" class="CT" element="C" mass="12.0108"/>
+  <Type name="462" class="CT" element="C" mass="12.0108"/>
+  <Type name="464" class="C" element="C" mass="12.0108"/>
+  <Type name="465" class="O2" element="O" mass="15.9994"/>
+  <Type name="466" class="O2" element="O" mass="15.9994"/>
+  <Type name="467" class="C" element="C" mass="12.0108"/>
+  <Type name="468" class="O2" element="O" mass="15.9994"/>
+  <Type name="469" class="O2" element="O" mass="15.9994"/>
+  <Type name="470" class="N" element="N" mass="14.0067"/>
+  <Type name="472" class="CT" element="C" mass="12.0108"/>
+  <Type name="474" class="C" element="C" mass="12.0108"/>
+  <Type name="475" class="O2" element="O" mass="15.9994"/>
+  <Type name="476" class="O2" element="O" mass="15.9994"/>
+  <Type name="477" class="N" element="N" mass="14.0067"/>
+  <Type name="479" class="CT" element="C" mass="12.0108"/>
+  <Type name="481" class="CT" element="C" mass="12.0108"/>
+  <Type name="483" class="CC" element="C" mass="12.0108"/>
   <Type name="484" class="NA" element="N" mass="14.0067"/>
-  <Type name="1635" class="CT" element="C" mass="12.0108"/>
-  <Type name="1637" class="OS" element="O" mass="15.9994"/>
-  <Type name="1638" class="CT" element="C" mass="12.0108"/>
-  <Type name="569" class="CT" element="C" mass="12.0108"/>
+  <Type name="486" class="CR" element="C" mass="12.0108"/>
+  <Type name="488" class="NB" element="N" mass="14.0067"/>
+  <Type name="489" class="CV" element="C" mass="12.0108"/>
+  <Type name="491" class="C" element="C" mass="12.0108"/>
+  <Type name="492" class="O2" element="O" mass="15.9994"/>
+  <Type name="493" class="O2" element="O" mass="15.9994"/>
+  <Type name="494" class="N" element="N" mass="14.0067"/>
+  <Type name="496" class="CT" element="C" mass="12.0108"/>
+  <Type name="498" class="CT" element="C" mass="12.0108"/>
+  <Type name="500" class="CC" element="C" mass="12.0108"/>
+  <Type name="501" class="NB" element="N" mass="14.0067"/>
+  <Type name="502" class="CR" element="C" mass="12.0108"/>
+  <Type name="504" class="NA" element="N" mass="14.0067"/>
+  <Type name="506" class="CW" element="C" mass="12.0108"/>
+  <Type name="508" class="C" element="C" mass="12.0108"/>
+  <Type name="509" class="O2" element="O" mass="15.9994"/>
+  <Type name="510" class="O2" element="O" mass="15.9994"/>
+  <Type name="511" class="N" element="N" mass="14.0067"/>
+  <Type name="513" class="CT" element="C" mass="12.0108"/>
+  <Type name="515" class="CT" element="C" mass="12.0108"/>
+  <Type name="517" class="CC" element="C" mass="12.0108"/>
+  <Type name="518" class="NA" element="N" mass="14.0067"/>
+  <Type name="520" class="CR" element="C" mass="12.0108"/>
+  <Type name="522" class="NA" element="N" mass="14.0067"/>
+  <Type name="524" class="CW" element="C" mass="12.0108"/>
+  <Type name="526" class="C" element="C" mass="12.0108"/>
+  <Type name="527" class="O2" element="O" mass="15.9994"/>
+  <Type name="528" class="O2" element="O" mass="15.9994"/>
+  <Type name="529" class="N" element="N" mass="14.0067"/>
+  <Type name="531" class="CT" element="C" mass="12.0108"/>
+  <Type name="533" class="CT" element="C" mass="12.0108"/>
+  <Type name="535" class="CT" element="C" mass="12.0108"/>
+  <Type name="537" class="CT" element="C" mass="12.0108"/>
+  <Type name="539" class="CT" element="C" mass="12.0108"/>
+  <Type name="541" class="C" element="C" mass="12.0108"/>
+  <Type name="542" class="O2" element="O" mass="15.9994"/>
+  <Type name="543" class="O2" element="O" mass="15.9994"/>
+  <Type name="544" class="N" element="N" mass="14.0067"/>
+  <Type name="546" class="CT" element="C" mass="12.0108"/>
+  <Type name="548" class="CT" element="C" mass="12.0108"/>
+  <Type name="550" class="C4" element="C" mass="12.0108"/>
+  <Type name="552" class="CT" element="C" mass="12.0108"/>
+  <Type name="554" class="CT" element="C" mass="12.0108"/>
+  <Type name="556" class="C" element="C" mass="12.0108"/>
+  <Type name="557" class="O2" element="O" mass="15.9994"/>
+  <Type name="558" class="O2" element="O" mass="15.9994"/>
+  <Type name="559" class="N" element="N" mass="14.0067"/>
   <Type name="561" class="CT" element="C" mass="12.0108"/>
   <Type name="563" class="CT" element="C" mass="12.0108"/>
   <Type name="565" class="CT" element="C" mass="12.0108"/>
   <Type name="567" class="CT" element="C" mass="12.0108"/>
-  <Type name="1188" class="N2" element="N" mass="14.0067"/>
-  <Type name="1187" class="CA" element="C" mass="12.0108"/>
-  <Type name="1185" class="CM" element="C" mass="12.0108"/>
-  <Type name="1182" class="N*" element="N" mass="14.0067"/>
-  <Type name="1183" class="CM" element="C" mass="12.0108"/>
-  <Type name="1180" class="CT" element="C" mass="12.0108"/>
-  <Type name="726" class="CT" element="C" mass="12.0108"/>
-  <Type name="724" class="CT" element="C" mass="12.0108"/>
-  <Type name="722" class="N3" element="N" mass="14.0067"/>
+  <Type name="569" class="CT" element="C" mass="12.0108"/>
+  <Type name="571" class="N3" element="N" mass="14.0067"/>
+  <Type name="573" class="C" element="C" mass="12.0108"/>
+  <Type name="574" class="O2" element="O" mass="15.9994"/>
+  <Type name="575" class="O2" element="O" mass="15.9994"/>
+  <Type name="576" class="N" element="N" mass="14.0067"/>
+  <Type name="578" class="CT" element="C" mass="12.0108"/>
+  <Type name="580" class="CT" element="C" mass="12.0108"/>
+  <Type name="582" class="CT" element="C" mass="12.0108"/>
+  <Type name="584" class="S" element="S" mass="32.0655"/>
+  <Type name="585" class="CT" element="C" mass="12.0108"/>
+  <Type name="587" class="C" element="C" mass="12.0108"/>
+  <Type name="588" class="O2" element="O" mass="15.9994"/>
+  <Type name="589" class="O2" element="O" mass="15.9994"/>
+  <Type name="590" class="N" element="N" mass="14.0067"/>
+  <Type name="592" class="CT" element="C" mass="12.0108"/>
+  <Type name="594" class="CT" element="C" mass="12.0108"/>
+  <Type name="596" class="CA" element="C" mass="12.0108"/>
+  <Type name="597" class="CA" element="C" mass="12.0108"/>
+  <Type name="599" class="CA" element="C" mass="12.0108"/>
+  <Type name="601" class="CA" element="C" mass="12.0108"/>
+  <Type name="603" class="CA" element="C" mass="12.0108"/>
+  <Type name="605" class="CA" element="C" mass="12.0108"/>
+  <Type name="607" class="C" element="C" mass="12.0108"/>
+  <Type name="608" class="O2" element="O" mass="15.9994"/>
+  <Type name="609" class="O2" element="O" mass="15.9994"/>
+  <Type name="610" class="N" element="N" mass="14.0067"/>
+  <Type name="611" class="CT" element="C" mass="12.0108"/>
+  <Type name="613" class="CT" element="C" mass="12.0108"/>
+  <Type name="615" class="CT" element="C" mass="12.0108"/>
+  <Type name="617" class="CT" element="C" mass="12.0108"/>
+  <Type name="619" class="C" element="C" mass="12.0108"/>
+  <Type name="620" class="O2" element="O" mass="15.9994"/>
+  <Type name="621" class="O2" element="O" mass="15.9994"/>
+  <Type name="622" class="N" element="N" mass="14.0067"/>
+  <Type name="624" class="CT" element="C" mass="12.0108"/>
+  <Type name="626" class="CT" element="C" mass="12.0108"/>
+  <Type name="628" class="OH" element="O" mass="15.9994"/>
+  <Type name="630" class="C" element="C" mass="12.0108"/>
+  <Type name="631" class="O2" element="O" mass="15.9994"/>
+  <Type name="632" class="O2" element="O" mass="15.9994"/>
+  <Type name="633" class="N" element="N" mass="14.0067"/>
+  <Type name="635" class="CT" element="C" mass="12.0108"/>
+  <Type name="637" class="CT" element="C" mass="12.0108"/>
+  <Type name="639" class="CT" element="C" mass="12.0108"/>
+  <Type name="641" class="OH" element="O" mass="15.9994"/>
+  <Type name="643" class="C" element="C" mass="12.0108"/>
+  <Type name="644" class="O2" element="O" mass="15.9994"/>
+  <Type name="645" class="O2" element="O" mass="15.9994"/>
+  <Type name="646" class="N" element="N" mass="14.0067"/>
+  <Type name="648" class="CT" element="C" mass="12.0108"/>
+  <Type name="650" class="CT" element="C" mass="12.0108"/>
+  <Type name="652" class="C*" element="C" mass="12.0108"/>
+  <Type name="653" class="CW" element="C" mass="12.0108"/>
+  <Type name="655" class="NA" element="N" mass="14.0067"/>
+  <Type name="657" class="CN" element="C" mass="12.0108"/>
+  <Type name="658" class="CA" element="C" mass="12.0108"/>
+  <Type name="660" class="CA" element="C" mass="12.0108"/>
+  <Type name="662" class="CA" element="C" mass="12.0108"/>
+  <Type name="664" class="CA" element="C" mass="12.0108"/>
+  <Type name="666" class="CB" element="C" mass="12.0108"/>
+  <Type name="667" class="C" element="C" mass="12.0108"/>
+  <Type name="668" class="O2" element="O" mass="15.9994"/>
+  <Type name="669" class="O2" element="O" mass="15.9994"/>
+  <Type name="670" class="N" element="N" mass="14.0067"/>
+  <Type name="672" class="CT" element="C" mass="12.0108"/>
+  <Type name="674" class="CT" element="C" mass="12.0108"/>
+  <Type name="676" class="CA" element="C" mass="12.0108"/>
+  <Type name="677" class="CA" element="C" mass="12.0108"/>
+  <Type name="679" class="CA" element="C" mass="12.0108"/>
+  <Type name="681" class="C" element="C" mass="12.0108"/>
+  <Type name="682" class="OH" element="O" mass="15.9994"/>
+  <Type name="684" class="CA" element="C" mass="12.0108"/>
+  <Type name="686" class="CA" element="C" mass="12.0108"/>
+  <Type name="688" class="C" element="C" mass="12.0108"/>
+  <Type name="689" class="O2" element="O" mass="15.9994"/>
+  <Type name="690" class="O2" element="O" mass="15.9994"/>
+  <Type name="691" class="N" element="N" mass="14.0067"/>
+  <Type name="693" class="CT" element="C" mass="12.0108"/>
+  <Type name="695" class="CT" element="C" mass="12.0108"/>
+  <Type name="697" class="CT" element="C" mass="12.0108"/>
+  <Type name="699" class="CT" element="C" mass="12.0108"/>
+  <Type name="701" class="C" element="C" mass="12.0108"/>
+  <Type name="702" class="O2" element="O" mass="15.9994"/>
+  <Type name="703" class="O2" element="O" mass="15.9994"/>
+  <Type name="704" class="N" element="N" mass="14.0067"/>
+  <Type name="706" class="N" element="N" mass="14.0067"/>
+  <Type name="708" class="CT" element="C" mass="12.0108"/>
+  <Type name="711" class="CT" element="C" mass="12.0108"/>
+  <Type name="712" class="C" element="C" mass="12.0108"/>
+  <Type name="713" class="O" element="O" mass="15.9994"/>
+  <Type name="714" class="N3" element="N" mass="14.0067"/>
+  <Type name="716" class="CT" element="C" mass="12.0108"/>
+  <Type name="718" class="CT" element="C" mass="12.0108"/>
   <Type name="720" class="C" element="C" mass="12.0108"/>
   <Type name="721" class="O" element="O" mass="15.9994"/>
-  <Type name="1745" class="OS" element="O" mass="15.9994"/>
-  <Type name="1746" class="P" element="P" mass="30.9738"/>
-  <Type name="1747" class="O2" element="O" mass="15.9994"/>
-  <Type name="1741" class="CT" element="C" mass="12.0108"/>
+  <Type name="722" class="N3" element="N" mass="14.0067"/>
+  <Type name="724" class="CT" element="C" mass="12.0108"/>
+  <Type name="726" class="CT" element="C" mass="12.0108"/>
   <Type name="728" class="CT" element="C" mass="12.0108"/>
-  <Type name="1164" class="C" element="C" mass="12.0108"/>
-  <Type name="1165" class="O" element="O" mass="15.9994"/>
-  <Type name="1166" class="CT" element="C" mass="12.0108"/>
+  <Type name="730" class="CT" element="C" mass="12.0108"/>
+  <Type name="732" class="N2" element="N" mass="14.0067"/>
+  <Type name="734" class="CA" element="C" mass="12.0108"/>
+  <Type name="735" class="N2" element="N" mass="14.0067"/>
+  <Type name="737" class="N2" element="N" mass="14.0067"/>
+  <Type name="739" class="C" element="C" mass="12.0108"/>
+  <Type name="740" class="O" element="O" mass="15.9994"/>
+  <Type name="741" class="N3" element="N" mass="14.0067"/>
+  <Type name="743" class="CT" element="C" mass="12.0108"/>
+  <Type name="745" class="CT" element="C" mass="12.0108"/>
+  <Type name="747" class="C5" element="C" mass="12.0108"/>
+  <Type name="748" class="O" element="O" mass="15.9994"/>
+  <Type name="749" class="N" element="N" mass="14.0067"/>
+  <Type name="751" class="C" element="C" mass="12.0108"/>
+  <Type name="752" class="O" element="O" mass="15.9994"/>
+  <Type name="753" class="N3" element="N" mass="14.0067"/>
+  <Type name="755" class="CT" element="C" mass="12.0108"/>
+  <Type name="757" class="CT" element="C" mass="12.0108"/>
+  <Type name="759" class="C6" element="C" mass="12.0108"/>
+  <Type name="760" class="O2" element="O" mass="15.9994"/>
+  <Type name="761" class="O2" element="O" mass="15.9994"/>
+  <Type name="762" class="C" element="C" mass="12.0108"/>
+  <Type name="763" class="O" element="O" mass="15.9994"/>
+  <Type name="764" class="N3" element="N" mass="14.0067"/>
+  <Type name="766" class="CT" element="C" mass="12.0108"/>
+  <Type name="768" class="CT" element="C" mass="12.0108"/>
+  <Type name="770" class="SH" element="S" mass="32.0655"/>
+  <Type name="772" class="C" element="C" mass="12.0108"/>
+  <Type name="773" class="O" element="O" mass="15.9994"/>
+  <Type name="774" class="N3" element="N" mass="14.0067"/>
+  <Type name="776" class="CT" element="C" mass="12.0108"/>
+  <Type name="778" class="CT" element="C" mass="12.0108"/>
+  <Type name="780" class="S" element="S" mass="32.0655"/>
+  <Type name="781" class="C" element="C" mass="12.0108"/>
+  <Type name="782" class="O" element="O" mass="15.9994"/>
+  <Type name="783" class="N3" element="N" mass="14.0067"/>
+  <Type name="785" class="CT" element="C" mass="12.0108"/>
+  <Type name="787" class="CT" element="C" mass="12.0108"/>
+  <Type name="789" class="CT" element="C" mass="12.0108"/>
+  <Type name="791" class="C" element="C" mass="12.0108"/>
+  <Type name="792" class="O" element="O" mass="15.9994"/>
+  <Type name="793" class="N" element="N" mass="14.0067"/>
+  <Type name="795" class="C" element="C" mass="12.0108"/>
+  <Type name="796" class="O" element="O" mass="15.9994"/>
+  <Type name="797" class="N3" element="N" mass="14.0067"/>
+  <Type name="799" class="CT" element="C" mass="12.0108"/>
+  <Type name="801" class="CT" element="C" mass="12.0108"/>
+  <Type name="803" class="CT" element="C" mass="12.0108"/>
+  <Type name="805" class="C" element="C" mass="12.0108"/>
+  <Type name="806" class="O2" element="O" mass="15.9994"/>
+  <Type name="807" class="O2" element="O" mass="15.9994"/>
+  <Type name="808" class="C" element="C" mass="12.0108"/>
+  <Type name="809" class="O" element="O" mass="15.9994"/>
+  <Type name="810" class="N3" element="N" mass="14.0067"/>
+  <Type name="812" class="CT" element="C" mass="12.0108"/>
+  <Type name="814" class="C" element="C" mass="12.0108"/>
+  <Type name="815" class="O" element="O" mass="15.9994"/>
+  <Type name="816" class="N3" element="N" mass="14.0067"/>
+  <Type name="818" class="CT" element="C" mass="12.0108"/>
+  <Type name="820" class="CT" element="C" mass="12.0108"/>
+  <Type name="822" class="CC" element="C" mass="12.0108"/>
+  <Type name="823" class="NA" element="N" mass="14.0067"/>
+  <Type name="825" class="CR" element="C" mass="12.0108"/>
+  <Type name="827" class="NB" element="N" mass="14.0067"/>
+  <Type name="828" class="CV" element="C" mass="12.0108"/>
+  <Type name="830" class="C" element="C" mass="12.0108"/>
+  <Type name="831" class="O" element="O" mass="15.9994"/>
+  <Type name="832" class="N3" element="N" mass="14.0067"/>
+  <Type name="834" class="CT" element="C" mass="12.0108"/>
+  <Type name="836" class="CT" element="C" mass="12.0108"/>
+  <Type name="838" class="CC" element="C" mass="12.0108"/>
+  <Type name="839" class="NB" element="N" mass="14.0067"/>
+  <Type name="840" class="CR" element="C" mass="12.0108"/>
+  <Type name="842" class="NA" element="N" mass="14.0067"/>
+  <Type name="844" class="CW" element="C" mass="12.0108"/>
+  <Type name="846" class="C" element="C" mass="12.0108"/>
+  <Type name="847" class="O" element="O" mass="15.9994"/>
+  <Type name="848" class="N3" element="N" mass="14.0067"/>
+  <Type name="850" class="CT" element="C" mass="12.0108"/>
+  <Type name="852" class="CT" element="C" mass="12.0108"/>
+  <Type name="854" class="CC" element="C" mass="12.0108"/>
+  <Type name="855" class="NA" element="N" mass="14.0067"/>
+  <Type name="857" class="CR" element="C" mass="12.0108"/>
+  <Type name="859" class="NA" element="N" mass="14.0067"/>
+  <Type name="861" class="CW" element="C" mass="12.0108"/>
+  <Type name="863" class="C" element="C" mass="12.0108"/>
+  <Type name="864" class="O" element="O" mass="15.9994"/>
+  <Type name="865" class="N3" element="N" mass="14.0067"/>
+  <Type name="867" class="CT" element="C" mass="12.0108"/>
+  <Type name="869" class="CT" element="C" mass="12.0108"/>
+  <Type name="871" class="CT" element="C" mass="12.0108"/>
+  <Type name="873" class="CT" element="C" mass="12.0108"/>
+  <Type name="875" class="CT" element="C" mass="12.0108"/>
+  <Type name="877" class="C" element="C" mass="12.0108"/>
+  <Type name="878" class="O" element="O" mass="15.9994"/>
+  <Type name="879" class="N3" element="N" mass="14.0067"/>
+  <Type name="881" class="CT" element="C" mass="12.0108"/>
+  <Type name="883" class="CT" element="C" mass="12.0108"/>
+  <Type name="885" class="C4" element="C" mass="12.0108"/>
+  <Type name="887" class="CT" element="C" mass="12.0108"/>
+  <Type name="889" class="CT" element="C" mass="12.0108"/>
+  <Type name="891" class="C" element="C" mass="12.0108"/>
+  <Type name="892" class="O" element="O" mass="15.9994"/>
+  <Type name="893" class="N3" element="N" mass="14.0067"/>
+  <Type name="895" class="CT" element="C" mass="12.0108"/>
+  <Type name="897" class="CT" element="C" mass="12.0108"/>
+  <Type name="899" class="CT" element="C" mass="12.0108"/>
+  <Type name="901" class="CT" element="C" mass="12.0108"/>
+  <Type name="903" class="CT" element="C" mass="12.0108"/>
+  <Type name="905" class="N3" element="N" mass="14.0067"/>
+  <Type name="907" class="C" element="C" mass="12.0108"/>
+  <Type name="908" class="O" element="O" mass="15.9994"/>
+  <Type name="909" class="N3" element="N" mass="14.0067"/>
+  <Type name="911" class="CT" element="C" mass="12.0108"/>
+  <Type name="913" class="CT" element="C" mass="12.0108"/>
+  <Type name="915" class="CT" element="C" mass="12.0108"/>
+  <Type name="917" class="S" element="S" mass="32.0655"/>
+  <Type name="918" class="CT" element="C" mass="12.0108"/>
+  <Type name="920" class="C" element="C" mass="12.0108"/>
+  <Type name="921" class="O" element="O" mass="15.9994"/>
+  <Type name="922" class="N3" element="N" mass="14.0067"/>
+  <Type name="924" class="CT" element="C" mass="12.0108"/>
+  <Type name="926" class="CT" element="C" mass="12.0108"/>
+  <Type name="928" class="CA" element="C" mass="12.0108"/>
+  <Type name="929" class="CA" element="C" mass="12.0108"/>
+  <Type name="931" class="CA" element="C" mass="12.0108"/>
+  <Type name="933" class="CA" element="C" mass="12.0108"/>
+  <Type name="935" class="CA" element="C" mass="12.0108"/>
+  <Type name="937" class="CA" element="C" mass="12.0108"/>
+  <Type name="939" class="C" element="C" mass="12.0108"/>
+  <Type name="940" class="O" element="O" mass="15.9994"/>
+  <Type name="941" class="N3" element="N" mass="14.0067"/>
+  <Type name="943" class="CT" element="C" mass="12.0108"/>
+  <Type name="945" class="CT" element="C" mass="12.0108"/>
+  <Type name="947" class="CT" element="C" mass="12.0108"/>
+  <Type name="949" class="CT" element="C" mass="12.0108"/>
+  <Type name="951" class="C" element="C" mass="12.0108"/>
+  <Type name="952" class="O" element="O" mass="15.9994"/>
+  <Type name="953" class="N3" element="N" mass="14.0067"/>
+  <Type name="955" class="CT" element="C" mass="12.0108"/>
+  <Type name="957" class="CT" element="C" mass="12.0108"/>
+  <Type name="959" class="OH" element="O" mass="15.9994"/>
+  <Type name="961" class="C" element="C" mass="12.0108"/>
+  <Type name="962" class="O" element="O" mass="15.9994"/>
+  <Type name="963" class="N3" element="N" mass="14.0067"/>
+  <Type name="965" class="CT" element="C" mass="12.0108"/>
+  <Type name="967" class="CT" element="C" mass="12.0108"/>
+  <Type name="969" class="CT" element="C" mass="12.0108"/>
+  <Type name="971" class="OH" element="O" mass="15.9994"/>
+  <Type name="973" class="C" element="C" mass="12.0108"/>
+  <Type name="974" class="O" element="O" mass="15.9994"/>
+  <Type name="975" class="N3" element="N" mass="14.0067"/>
+  <Type name="977" class="CT" element="C" mass="12.0108"/>
+  <Type name="979" class="CT" element="C" mass="12.0108"/>
+  <Type name="981" class="C*" element="C" mass="12.0108"/>
+  <Type name="982" class="CW" element="C" mass="12.0108"/>
+  <Type name="984" class="NA" element="N" mass="14.0067"/>
+  <Type name="986" class="CN" element="C" mass="12.0108"/>
+  <Type name="987" class="CA" element="C" mass="12.0108"/>
+  <Type name="989" class="CA" element="C" mass="12.0108"/>
+  <Type name="991" class="CA" element="C" mass="12.0108"/>
+  <Type name="993" class="CA" element="C" mass="12.0108"/>
+  <Type name="995" class="CB" element="C" mass="12.0108"/>
+  <Type name="996" class="C" element="C" mass="12.0108"/>
+  <Type name="997" class="O" element="O" mass="15.9994"/>
+  <Type name="998" class="N3" element="N" mass="14.0067"/>
+  <Type name="1000" class="CT" element="C" mass="12.0108"/>
+  <Type name="1002" class="CT" element="C" mass="12.0108"/>
+  <Type name="1004" class="CA" element="C" mass="12.0108"/>
+  <Type name="1005" class="CA" element="C" mass="12.0108"/>
+  <Type name="1007" class="CA" element="C" mass="12.0108"/>
+  <Type name="1009" class="C" element="C" mass="12.0108"/>
+  <Type name="1010" class="OH" element="O" mass="15.9994"/>
+  <Type name="1012" class="CA" element="C" mass="12.0108"/>
+  <Type name="1014" class="CA" element="C" mass="12.0108"/>
+  <Type name="1016" class="C" element="C" mass="12.0108"/>
+  <Type name="1017" class="O" element="O" mass="15.9994"/>
+  <Type name="1018" class="N3" element="N" mass="14.0067"/>
+  <Type name="1020" class="CT" element="C" mass="12.0108"/>
+  <Type name="1022" class="CT" element="C" mass="12.0108"/>
+  <Type name="1024" class="CT" element="C" mass="12.0108"/>
+  <Type name="1026" class="CT" element="C" mass="12.0108"/>
+  <Type name="1028" class="C" element="C" mass="12.0108"/>
+  <Type name="1029" class="O" element="O" mass="15.9994"/>
+  <Type name="1030" class="P" element="P" mass="30.9738"/>
+  <Type name="1031" class="O2" element="O" mass="15.9994"/>
+  <Type name="1032" class="O2" element="O" mass="15.9994"/>
+  <Type name="1033" class="OS" element="O" mass="15.9994"/>
+  <Type name="1034" class="CT" element="C" mass="12.0108"/>
+  <Type name="1036" class="CT" element="C" mass="12.0108"/>
+  <Type name="1038" class="OS" element="O" mass="15.9994"/>
+  <Type name="1039" class="CT" element="C" mass="12.0108"/>
+  <Type name="1041" class="N*" element="N" mass="14.0067"/>
+  <Type name="1042" class="CK" element="C" mass="12.0108"/>
+  <Type name="1044" class="NB" element="N" mass="14.0067"/>
+  <Type name="1045" class="CB" element="C" mass="12.0108"/>
+  <Type name="1046" class="CA" element="C" mass="12.0108"/>
+  <Type name="1047" class="N2" element="N" mass="14.0067"/>
+  <Type name="1049" class="NC" element="N" mass="14.0067"/>
+  <Type name="1050" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1052" class="NC" element="N" mass="14.0067"/>
+  <Type name="1053" class="CB" element="C" mass="12.0108"/>
+  <Type name="1054" class="CT" element="C" mass="12.0108"/>
+  <Type name="1056" class="CT" element="C" mass="12.0108"/>
+  <Type name="1058" class="OS" element="O" mass="15.9994"/>
+  <Type name="1059" class="P" element="P" mass="30.9738"/>
+  <Type name="1060" class="O2" element="O" mass="15.9994"/>
+  <Type name="1061" class="O2" element="O" mass="15.9994"/>
+  <Type name="1062" class="OS" element="O" mass="15.9994"/>
+  <Type name="1063" class="CT" element="C" mass="12.0108"/>
+  <Type name="1065" class="CT" element="C" mass="12.0108"/>
+  <Type name="1067" class="OS" element="O" mass="15.9994"/>
+  <Type name="1068" class="CT" element="C" mass="12.0108"/>
+  <Type name="1070" class="N*" element="N" mass="14.0067"/>
+  <Type name="1071" class="CK" element="C" mass="12.0108"/>
+  <Type name="1073" class="NB" element="N" mass="14.0067"/>
+  <Type name="1074" class="CB" element="C" mass="12.0108"/>
+  <Type name="1075" class="CA" element="C" mass="12.0108"/>
+  <Type name="1076" class="N2" element="N" mass="14.0067"/>
+  <Type name="1078" class="NC" element="N" mass="14.0067"/>
+  <Type name="1079" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1081" class="NC" element="N" mass="14.0067"/>
+  <Type name="1082" class="CB" element="C" mass="12.0108"/>
+  <Type name="1083" class="CT" element="C" mass="12.0108"/>
+  <Type name="1085" class="CT" element="C" mass="12.0108"/>
+  <Type name="1087" class="OH" element="O" mass="15.9994"/>
+  <Type name="1090" class="OH" element="O" mass="15.9994"/>
+  <Type name="1091" class="CT" element="C" mass="12.0108"/>
+  <Type name="1093" class="CT" element="C" mass="12.0108"/>
+  <Type name="1095" class="OS" element="O" mass="15.9994"/>
+  <Type name="1096" class="CT" element="C" mass="12.0108"/>
+  <Type name="1098" class="N*" element="N" mass="14.0067"/>
+  <Type name="1099" class="CK" element="C" mass="12.0108"/>
+  <Type name="1101" class="NB" element="N" mass="14.0067"/>
+  <Type name="1102" class="CB" element="C" mass="12.0108"/>
+  <Type name="1103" class="CA" element="C" mass="12.0108"/>
+  <Type name="1104" class="N2" element="N" mass="14.0067"/>
+  <Type name="1106" class="NC" element="N" mass="14.0067"/>
+  <Type name="1107" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1109" class="NC" element="N" mass="14.0067"/>
+  <Type name="1110" class="CB" element="C" mass="12.0108"/>
+  <Type name="1111" class="CT" element="C" mass="12.0108"/>
+  <Type name="1113" class="CT" element="C" mass="12.0108"/>
+  <Type name="1115" class="OS" element="O" mass="15.9994"/>
+  <Type name="1117" class="OH" element="O" mass="15.9994"/>
+  <Type name="1118" class="CT" element="C" mass="12.0108"/>
+  <Type name="1120" class="CT" element="C" mass="12.0108"/>
+  <Type name="1122" class="OS" element="O" mass="15.9994"/>
+  <Type name="1123" class="CT" element="C" mass="12.0108"/>
+  <Type name="1125" class="N*" element="N" mass="14.0067"/>
+  <Type name="1126" class="CK" element="C" mass="12.0108"/>
+  <Type name="1128" class="NB" element="N" mass="14.0067"/>
+  <Type name="1129" class="CB" element="C" mass="12.0108"/>
+  <Type name="1130" class="CA" element="C" mass="12.0108"/>
+  <Type name="1131" class="N2" element="N" mass="14.0067"/>
+  <Type name="1133" class="NC" element="N" mass="14.0067"/>
+  <Type name="1134" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1136" class="NC" element="N" mass="14.0067"/>
+  <Type name="1137" class="CB" element="C" mass="12.0108"/>
+  <Type name="1138" class="CT" element="C" mass="12.0108"/>
+  <Type name="1140" class="CT" element="C" mass="12.0108"/>
+  <Type name="1142" class="OH" element="O" mass="15.9994"/>
+  <Type name="1144" class="P" element="P" mass="30.9738"/>
+  <Type name="1145" class="O2" element="O" mass="15.9994"/>
+  <Type name="1146" class="O2" element="O" mass="15.9994"/>
+  <Type name="1147" class="OS" element="O" mass="15.9994"/>
+  <Type name="1148" class="CT" element="C" mass="12.0108"/>
+  <Type name="1150" class="CT" element="C" mass="12.0108"/>
+  <Type name="1152" class="OS" element="O" mass="15.9994"/>
+  <Type name="1153" class="CT" element="C" mass="12.0108"/>
+  <Type name="1155" class="N*" element="N" mass="14.0067"/>
+  <Type name="1156" class="CM" element="C" mass="12.0108"/>
+  <Type name="1158" class="CM" element="C" mass="12.0108"/>
   <Type name="1160" class="CA" element="C" mass="12.0108"/>
   <Type name="1161" class="N2" element="N" mass="14.0067"/>
   <Type name="1163" class="NC" element="N" mass="14.0067"/>
+  <Type name="1164" class="C" element="C" mass="12.0108"/>
+  <Type name="1165" class="O" element="O" mass="15.9994"/>
+  <Type name="1166" class="CT" element="C" mass="12.0108"/>
   <Type name="1168" class="CT" element="C" mass="12.0108"/>
-  <Type name="1366" class="OH" element="O" mass="15.9994"/>
-  <Type name="49" class="C" element="C" mass="12.0108"/>
-  <Type name="46" class="O" element="O" mass="15.9994"/>
-  <Type name="47" class="N" element="N" mass="14.0067"/>
-  <Type name="45" class="C5" element="C" mass="12.0108"/>
-  <Type name="43" class="CT" element="C" mass="12.0108"/>
-  <Type name="41" class="CT" element="C" mass="12.0108"/>
-  <Type name="1569" class="OS" element="O" mass="15.9994"/>
-  <Type name="1298" class="NA" element="N" mass="14.0067"/>
-  <Type name="1292" class="CK" element="C" mass="12.0108"/>
+  <Type name="1170" class="OS" element="O" mass="15.9994"/>
+  <Type name="1171" class="P" element="P" mass="30.9738"/>
+  <Type name="1172" class="O2" element="O" mass="15.9994"/>
+  <Type name="1173" class="O2" element="O" mass="15.9994"/>
+  <Type name="1174" class="OS" element="O" mass="15.9994"/>
+  <Type name="1175" class="CT" element="C" mass="12.0108"/>
+  <Type name="1177" class="CT" element="C" mass="12.0108"/>
+  <Type name="1179" class="OS" element="O" mass="15.9994"/>
+  <Type name="1180" class="CT" element="C" mass="12.0108"/>
+  <Type name="1182" class="N*" element="N" mass="14.0067"/>
+  <Type name="1183" class="CM" element="C" mass="12.0108"/>
+  <Type name="1185" class="CM" element="C" mass="12.0108"/>
+  <Type name="1187" class="CA" element="C" mass="12.0108"/>
+  <Type name="1188" class="N2" element="N" mass="14.0067"/>
+  <Type name="1190" class="NC" element="N" mass="14.0067"/>
+  <Type name="1191" class="C" element="C" mass="12.0108"/>
+  <Type name="1192" class="O" element="O" mass="15.9994"/>
+  <Type name="1193" class="CT" element="C" mass="12.0108"/>
+  <Type name="1195" class="CT" element="C" mass="12.0108"/>
+  <Type name="1197" class="OH" element="O" mass="15.9994"/>
+  <Type name="1200" class="OH" element="O" mass="15.9994"/>
+  <Type name="1201" class="CT" element="C" mass="12.0108"/>
+  <Type name="1203" class="CT" element="C" mass="12.0108"/>
+  <Type name="1205" class="OS" element="O" mass="15.9994"/>
+  <Type name="1206" class="CT" element="C" mass="12.0108"/>
+  <Type name="1208" class="N*" element="N" mass="14.0067"/>
+  <Type name="1209" class="CM" element="C" mass="12.0108"/>
+  <Type name="1211" class="CM" element="C" mass="12.0108"/>
+  <Type name="1213" class="CA" element="C" mass="12.0108"/>
+  <Type name="1214" class="N2" element="N" mass="14.0067"/>
+  <Type name="1216" class="NC" element="N" mass="14.0067"/>
+  <Type name="1217" class="C" element="C" mass="12.0108"/>
+  <Type name="1218" class="O" element="O" mass="15.9994"/>
+  <Type name="1219" class="CT" element="C" mass="12.0108"/>
+  <Type name="1221" class="CT" element="C" mass="12.0108"/>
+  <Type name="1223" class="OS" element="O" mass="15.9994"/>
+  <Type name="1225" class="OH" element="O" mass="15.9994"/>
+  <Type name="1226" class="CT" element="C" mass="12.0108"/>
+  <Type name="1228" class="CT" element="C" mass="12.0108"/>
+  <Type name="1230" class="OS" element="O" mass="15.9994"/>
+  <Type name="1231" class="CT" element="C" mass="12.0108"/>
+  <Type name="1233" class="N*" element="N" mass="14.0067"/>
+  <Type name="1234" class="CM" element="C" mass="12.0108"/>
+  <Type name="1236" class="CM" element="C" mass="12.0108"/>
+  <Type name="1238" class="CA" element="C" mass="12.0108"/>
+  <Type name="1239" class="N2" element="N" mass="14.0067"/>
+  <Type name="1241" class="NC" element="N" mass="14.0067"/>
+  <Type name="1242" class="C" element="C" mass="12.0108"/>
+  <Type name="1243" class="O" element="O" mass="15.9994"/>
+  <Type name="1244" class="CT" element="C" mass="12.0108"/>
+  <Type name="1246" class="CT" element="C" mass="12.0108"/>
+  <Type name="1248" class="OH" element="O" mass="15.9994"/>
+  <Type name="1250" class="P" element="P" mass="30.9738"/>
+  <Type name="1251" class="O2" element="O" mass="15.9994"/>
+  <Type name="1252" class="O2" element="O" mass="15.9994"/>
+  <Type name="1253" class="OS" element="O" mass="15.9994"/>
+  <Type name="1254" class="CT" element="C" mass="12.0108"/>
+  <Type name="1256" class="CT" element="C" mass="12.0108"/>
+  <Type name="1258" class="OS" element="O" mass="15.9994"/>
+  <Type name="1259" class="CT" element="C" mass="12.0108"/>
+  <Type name="1261" class="N*" element="N" mass="14.0067"/>
+  <Type name="1262" class="CK" element="C" mass="12.0108"/>
+  <Type name="1264" class="NB" element="N" mass="14.0067"/>
+  <Type name="1265" class="CB" element="C" mass="12.0108"/>
+  <Type name="1266" class="C" element="C" mass="12.0108"/>
+  <Type name="1267" class="O" element="O" mass="15.9994"/>
+  <Type name="1268" class="NA" element="N" mass="14.0067"/>
+  <Type name="1270" class="CA" element="C" mass="12.0108"/>
+  <Type name="1271" class="N2" element="N" mass="14.0067"/>
+  <Type name="1273" class="NC" element="N" mass="14.0067"/>
+  <Type name="1274" class="CB" element="C" mass="12.0108"/>
+  <Type name="1275" class="CT" element="C" mass="12.0108"/>
+  <Type name="1277" class="CT" element="C" mass="12.0108"/>
+  <Type name="1279" class="OS" element="O" mass="15.9994"/>
+  <Type name="1280" class="P" element="P" mass="30.9738"/>
+  <Type name="1281" class="O2" element="O" mass="15.9994"/>
+  <Type name="1282" class="O2" element="O" mass="15.9994"/>
+  <Type name="1283" class="OS" element="O" mass="15.9994"/>
+  <Type name="1284" class="CT" element="C" mass="12.0108"/>
+  <Type name="1286" class="CT" element="C" mass="12.0108"/>
+  <Type name="1288" class="OS" element="O" mass="15.9994"/>
+  <Type name="1289" class="CT" element="C" mass="12.0108"/>
   <Type name="1291" class="N*" element="N" mass="14.0067"/>
-  <Type name="1296" class="C" element="C" mass="12.0108"/>
-  <Type name="1297" class="O" element="O" mass="15.9994"/>
+  <Type name="1292" class="CK" element="C" mass="12.0108"/>
   <Type name="1294" class="NB" element="N" mass="14.0067"/>
   <Type name="1295" class="CB" element="C" mass="12.0108"/>
-  <Type name="474" class="C" element="C" mass="12.0108"/>
-  <Type name="1712" class="OH" element="O" mass="15.9994"/>
-  <Type name="475" class="O2" element="O" mass="15.9994"/>
-  <Type name="1710" class="OH" element="O" mass="15.9994"/>
-  <Type name="1717" class="OS" element="O" mass="15.9994"/>
-  <Type name="1716" class="O2" element="O" mass="15.9994"/>
-  <Type name="1715" class="O2" element="O" mass="15.9994"/>
-  <Type name="1201" class="CT" element="C" mass="12.0108"/>
-  <Type name="1714" class="P" element="P" mass="30.9738"/>
-  <Type name="472" class="CT" element="C" mass="12.0108"/>
-  <Type name="1364" class="CT" element="C" mass="12.0108"/>
-  <Type name="1362" class="CT" element="C" mass="12.0108"/>
+  <Type name="1296" class="C" element="C" mass="12.0108"/>
+  <Type name="1297" class="O" element="O" mass="15.9994"/>
+  <Type name="1298" class="NA" element="N" mass="14.0067"/>
+  <Type name="1300" class="CA" element="C" mass="12.0108"/>
+  <Type name="1301" class="N2" element="N" mass="14.0067"/>
+  <Type name="1303" class="NC" element="N" mass="14.0067"/>
+  <Type name="1304" class="CB" element="C" mass="12.0108"/>
+  <Type name="1305" class="CT" element="C" mass="12.0108"/>
+  <Type name="1307" class="CT" element="C" mass="12.0108"/>
+  <Type name="1309" class="OH" element="O" mass="15.9994"/>
+  <Type name="1312" class="OH" element="O" mass="15.9994"/>
+  <Type name="1313" class="CT" element="C" mass="12.0108"/>
+  <Type name="1315" class="CT" element="C" mass="12.0108"/>
+  <Type name="1317" class="OS" element="O" mass="15.9994"/>
+  <Type name="1318" class="CT" element="C" mass="12.0108"/>
+  <Type name="1320" class="N*" element="N" mass="14.0067"/>
+  <Type name="1321" class="CK" element="C" mass="12.0108"/>
+  <Type name="1323" class="NB" element="N" mass="14.0067"/>
+  <Type name="1324" class="CB" element="C" mass="12.0108"/>
+  <Type name="1325" class="C" element="C" mass="12.0108"/>
+  <Type name="1326" class="O" element="O" mass="15.9994"/>
+  <Type name="1327" class="NA" element="N" mass="14.0067"/>
+  <Type name="1329" class="CA" element="C" mass="12.0108"/>
+  <Type name="1330" class="N2" element="N" mass="14.0067"/>
+  <Type name="1332" class="NC" element="N" mass="14.0067"/>
+  <Type name="1333" class="CB" element="C" mass="12.0108"/>
+  <Type name="1334" class="CT" element="C" mass="12.0108"/>
+  <Type name="1336" class="CT" element="C" mass="12.0108"/>
+  <Type name="1338" class="OS" element="O" mass="15.9994"/>
+  <Type name="1340" class="OH" element="O" mass="15.9994"/>
+  <Type name="1341" class="CT" element="C" mass="12.0108"/>
+  <Type name="1343" class="CT" element="C" mass="12.0108"/>
+  <Type name="1345" class="OS" element="O" mass="15.9994"/>
+  <Type name="1346" class="CT" element="C" mass="12.0108"/>
+  <Type name="1348" class="N*" element="N" mass="14.0067"/>
+  <Type name="1349" class="CK" element="C" mass="12.0108"/>
+  <Type name="1351" class="NB" element="N" mass="14.0067"/>
+  <Type name="1352" class="CB" element="C" mass="12.0108"/>
+  <Type name="1353" class="C" element="C" mass="12.0108"/>
+  <Type name="1354" class="O" element="O" mass="15.9994"/>
+  <Type name="1355" class="NA" element="N" mass="14.0067"/>
+  <Type name="1357" class="CA" element="C" mass="12.0108"/>
+  <Type name="1358" class="N2" element="N" mass="14.0067"/>
   <Type name="1360" class="NC" element="N" mass="14.0067"/>
   <Type name="1361" class="CB" element="C" mass="12.0108"/>
-  <Type name="479" class="CT" element="C" mass="12.0108"/>
+  <Type name="1362" class="CT" element="C" mass="12.0108"/>
+  <Type name="1364" class="CT" element="C" mass="12.0108"/>
+  <Type name="1366" class="OH" element="O" mass="15.9994"/>
   <Type name="1368" class="P" element="P" mass="30.9738"/>
   <Type name="1369" class="O2" element="O" mass="15.9994"/>
+  <Type name="1370" class="O2" element="O" mass="15.9994"/>
+  <Type name="1371" class="OS" element="O" mass="15.9994"/>
+  <Type name="1372" class="CT" element="C" mass="12.0108"/>
+  <Type name="1374" class="CT" element="C" mass="12.0108"/>
+  <Type name="1376" class="OS" element="O" mass="15.9994"/>
+  <Type name="1377" class="CT" element="C" mass="12.0108"/>
+  <Type name="1379" class="N*" element="N" mass="14.0067"/>
+  <Type name="1380" class="CM" element="C" mass="12.0108"/>
+  <Type name="1382" class="CM" element="C" mass="12.0108"/>
+  <Type name="1383" class="CT" element="C" mass="12.0108"/>
+  <Type name="1385" class="C" element="C" mass="12.0108"/>
+  <Type name="1386" class="O" element="O" mass="15.9994"/>
+  <Type name="1387" class="NA" element="N" mass="14.0067"/>
+  <Type name="1389" class="C" element="C" mass="12.0108"/>
+  <Type name="1390" class="O" element="O" mass="15.9994"/>
+  <Type name="1391" class="CT" element="C" mass="12.0108"/>
+  <Type name="1393" class="CT" element="C" mass="12.0108"/>
+  <Type name="1395" class="OS" element="O" mass="15.9994"/>
+  <Type name="1396" class="P" element="P" mass="30.9738"/>
+  <Type name="1397" class="O2" element="O" mass="15.9994"/>
+  <Type name="1398" class="O2" element="O" mass="15.9994"/>
+  <Type name="1399" class="OS" element="O" mass="15.9994"/>
+  <Type name="1400" class="CT" element="C" mass="12.0108"/>
+  <Type name="1402" class="CT" element="C" mass="12.0108"/>
+  <Type name="1404" class="OS" element="O" mass="15.9994"/>
+  <Type name="1405" class="CT" element="C" mass="12.0108"/>
+  <Type name="1407" class="N*" element="N" mass="14.0067"/>
+  <Type name="1408" class="CM" element="C" mass="12.0108"/>
+  <Type name="1410" class="CM" element="C" mass="12.0108"/>
+  <Type name="1411" class="CT" element="C" mass="12.0108"/>
+  <Type name="1413" class="C" element="C" mass="12.0108"/>
+  <Type name="1414" class="O" element="O" mass="15.9994"/>
+  <Type name="1415" class="NA" element="N" mass="14.0067"/>
+  <Type name="1417" class="C" element="C" mass="12.0108"/>
+  <Type name="1418" class="O" element="O" mass="15.9994"/>
+  <Type name="1419" class="CT" element="C" mass="12.0108"/>
+  <Type name="1421" class="CT" element="C" mass="12.0108"/>
+  <Type name="1423" class="OH" element="O" mass="15.9994"/>
+  <Type name="1426" class="OH" element="O" mass="15.9994"/>
+  <Type name="1427" class="CT" element="C" mass="12.0108"/>
+  <Type name="1429" class="CT" element="C" mass="12.0108"/>
+  <Type name="1431" class="OS" element="O" mass="15.9994"/>
+  <Type name="1432" class="CT" element="C" mass="12.0108"/>
+  <Type name="1434" class="N*" element="N" mass="14.0067"/>
+  <Type name="1435" class="CM" element="C" mass="12.0108"/>
+  <Type name="1437" class="CM" element="C" mass="12.0108"/>
+  <Type name="1438" class="CT" element="C" mass="12.0108"/>
+  <Type name="1440" class="C" element="C" mass="12.0108"/>
+  <Type name="1441" class="O" element="O" mass="15.9994"/>
+  <Type name="1442" class="NA" element="N" mass="14.0067"/>
+  <Type name="1444" class="C" element="C" mass="12.0108"/>
+  <Type name="1445" class="O" element="O" mass="15.9994"/>
+  <Type name="1446" class="CT" element="C" mass="12.0108"/>
+  <Type name="1448" class="CT" element="C" mass="12.0108"/>
+  <Type name="1450" class="OS" element="O" mass="15.9994"/>
+  <Type name="1452" class="OH" element="O" mass="15.9994"/>
+  <Type name="1453" class="CT" element="C" mass="12.0108"/>
+  <Type name="1455" class="CT" element="C" mass="12.0108"/>
+  <Type name="1457" class="OS" element="O" mass="15.9994"/>
+  <Type name="1458" class="CT" element="C" mass="12.0108"/>
+  <Type name="1460" class="N*" element="N" mass="14.0067"/>
+  <Type name="1461" class="CM" element="C" mass="12.0108"/>
+  <Type name="1463" class="CM" element="C" mass="12.0108"/>
+  <Type name="1464" class="CT" element="C" mass="12.0108"/>
+  <Type name="1466" class="C" element="C" mass="12.0108"/>
+  <Type name="1467" class="O" element="O" mass="15.9994"/>
+  <Type name="1468" class="NA" element="N" mass="14.0067"/>
+  <Type name="1470" class="C" element="C" mass="12.0108"/>
+  <Type name="1471" class="O" element="O" mass="15.9994"/>
+  <Type name="1472" class="CT" element="C" mass="12.0108"/>
+  <Type name="1474" class="CT" element="C" mass="12.0108"/>
+  <Type name="1476" class="OH" element="O" mass="15.9994"/>
+  <Type name="1478" class="P" element="P" mass="30.9738"/>
+  <Type name="1479" class="O2" element="O" mass="15.9994"/>
+  <Type name="1480" class="O2" element="O" mass="15.9994"/>
+  <Type name="1481" class="OS" element="O" mass="15.9994"/>
+  <Type name="1482" class="CT" element="C" mass="12.0108"/>
+  <Type name="1484" class="CT" element="C" mass="12.0108"/>
+  <Type name="1486" class="OS" element="O" mass="15.9994"/>
+  <Type name="1487" class="CT" element="C" mass="12.0108"/>
+  <Type name="1489" class="N*" element="N" mass="14.0067"/>
+  <Type name="1490" class="CK" element="C" mass="12.0108"/>
+  <Type name="1492" class="NB" element="N" mass="14.0067"/>
+  <Type name="1493" class="CB" element="C" mass="12.0108"/>
+  <Type name="1494" class="CA" element="C" mass="12.0108"/>
+  <Type name="1495" class="N2" element="N" mass="14.0067"/>
+  <Type name="1497" class="NC" element="N" mass="14.0067"/>
+  <Type name="1498" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1500" class="NC" element="N" mass="14.0067"/>
+  <Type name="1501" class="CB" element="C" mass="12.0108"/>
+  <Type name="1502" class="CT" element="C" mass="12.0108"/>
+  <Type name="1504" class="CT" element="C" mass="12.0108"/>
+  <Type name="1506" class="OH" element="O" mass="15.9994"/>
+  <Type name="1508" class="OS" element="O" mass="15.9994"/>
+  <Type name="1509" class="P" element="P" mass="30.9738"/>
+  <Type name="1510" class="O2" element="O" mass="15.9994"/>
+  <Type name="1511" class="O2" element="O" mass="15.9994"/>
+  <Type name="1512" class="OS" element="O" mass="15.9994"/>
+  <Type name="1513" class="CT" element="C" mass="12.0108"/>
+  <Type name="1515" class="CT" element="C" mass="12.0108"/>
+  <Type name="1517" class="OS" element="O" mass="15.9994"/>
+  <Type name="1518" class="CT" element="C" mass="12.0108"/>
+  <Type name="1520" class="N*" element="N" mass="14.0067"/>
+  <Type name="1521" class="CK" element="C" mass="12.0108"/>
+  <Type name="1523" class="NB" element="N" mass="14.0067"/>
+  <Type name="1524" class="CB" element="C" mass="12.0108"/>
+  <Type name="1525" class="CA" element="C" mass="12.0108"/>
+  <Type name="1526" class="N2" element="N" mass="14.0067"/>
+  <Type name="1528" class="NC" element="N" mass="14.0067"/>
+  <Type name="1529" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1531" class="NC" element="N" mass="14.0067"/>
+  <Type name="1532" class="CB" element="C" mass="12.0108"/>
+  <Type name="1533" class="CT" element="C" mass="12.0108"/>
+  <Type name="1535" class="CT" element="C" mass="12.0108"/>
+  <Type name="1537" class="OH" element="O" mass="15.9994"/>
+  <Type name="1539" class="OH" element="O" mass="15.9994"/>
+  <Type name="1542" class="OH" element="O" mass="15.9994"/>
+  <Type name="1543" class="CT" element="C" mass="12.0108"/>
+  <Type name="1545" class="CT" element="C" mass="12.0108"/>
+  <Type name="1547" class="OS" element="O" mass="15.9994"/>
+  <Type name="1548" class="CT" element="C" mass="12.0108"/>
+  <Type name="1550" class="N*" element="N" mass="14.0067"/>
+  <Type name="1551" class="CK" element="C" mass="12.0108"/>
+  <Type name="1553" class="NB" element="N" mass="14.0067"/>
+  <Type name="1554" class="CB" element="C" mass="12.0108"/>
+  <Type name="1555" class="CA" element="C" mass="12.0108"/>
+  <Type name="1556" class="N2" element="N" mass="14.0067"/>
+  <Type name="1558" class="NC" element="N" mass="14.0067"/>
+  <Type name="1559" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1561" class="NC" element="N" mass="14.0067"/>
+  <Type name="1562" class="CB" element="C" mass="12.0108"/>
+  <Type name="1563" class="CT" element="C" mass="12.0108"/>
+  <Type name="1565" class="CT" element="C" mass="12.0108"/>
+  <Type name="1567" class="OH" element="O" mass="15.9994"/>
+  <Type name="1569" class="OS" element="O" mass="15.9994"/>
+  <Type name="1571" class="OH" element="O" mass="15.9994"/>
+  <Type name="1572" class="CT" element="C" mass="12.0108"/>
+  <Type name="1574" class="CT" element="C" mass="12.0108"/>
+  <Type name="1576" class="OS" element="O" mass="15.9994"/>
+  <Type name="1577" class="CT" element="C" mass="12.0108"/>
+  <Type name="1579" class="N*" element="N" mass="14.0067"/>
+  <Type name="1580" class="CK" element="C" mass="12.0108"/>
+  <Type name="1582" class="NB" element="N" mass="14.0067"/>
+  <Type name="1583" class="CB" element="C" mass="12.0108"/>
+  <Type name="1584" class="CA" element="C" mass="12.0108"/>
+  <Type name="1585" class="N2" element="N" mass="14.0067"/>
+  <Type name="1587" class="NC" element="N" mass="14.0067"/>
+  <Type name="1588" class="CQ" element="C" mass="12.0108"/>
+  <Type name="1590" class="NC" element="N" mass="14.0067"/>
+  <Type name="1591" class="CB" element="C" mass="12.0108"/>
+  <Type name="1592" class="CT" element="C" mass="12.0108"/>
+  <Type name="1594" class="CT" element="C" mass="12.0108"/>
+  <Type name="1596" class="OH" element="O" mass="15.9994"/>
+  <Type name="1598" class="OH" element="O" mass="15.9994"/>
+  <Type name="1600" class="P" element="P" mass="30.9738"/>
+  <Type name="1601" class="O2" element="O" mass="15.9994"/>
+  <Type name="1602" class="O2" element="O" mass="15.9994"/>
+  <Type name="1603" class="OS" element="O" mass="15.9994"/>
+  <Type name="1604" class="CT" element="C" mass="12.0108"/>
+  <Type name="1606" class="CT" element="C" mass="12.0108"/>
+  <Type name="1608" class="OS" element="O" mass="15.9994"/>
+  <Type name="1609" class="CT" element="C" mass="12.0108"/>
+  <Type name="1611" class="N*" element="N" mass="14.0067"/>
+  <Type name="1612" class="CM" element="C" mass="12.0108"/>
+  <Type name="1614" class="CM" element="C" mass="12.0108"/>
+  <Type name="1616" class="CA" element="C" mass="12.0108"/>
+  <Type name="1617" class="N2" element="N" mass="14.0067"/>
+  <Type name="1619" class="NC" element="N" mass="14.0067"/>
+  <Type name="1620" class="C" element="C" mass="12.0108"/>
+  <Type name="1621" class="O" element="O" mass="15.9994"/>
+  <Type name="1622" class="CT" element="C" mass="12.0108"/>
+  <Type name="1624" class="CT" element="C" mass="12.0108"/>
+  <Type name="1626" class="OH" element="O" mass="15.9994"/>
+  <Type name="1628" class="OS" element="O" mass="15.9994"/>
+  <Type name="1629" class="P" element="P" mass="30.9738"/>
+  <Type name="1630" class="O2" element="O" mass="15.9994"/>
+  <Type name="1631" class="O2" element="O" mass="15.9994"/>
+  <Type name="1632" class="OS" element="O" mass="15.9994"/>
+  <Type name="1633" class="CT" element="C" mass="12.0108"/>
+  <Type name="1635" class="CT" element="C" mass="12.0108"/>
+  <Type name="1637" class="OS" element="O" mass="15.9994"/>
+  <Type name="1638" class="CT" element="C" mass="12.0108"/>
+  <Type name="1640" class="N*" element="N" mass="14.0067"/>
+  <Type name="1641" class="CM" element="C" mass="12.0108"/>
+  <Type name="1643" class="CM" element="C" mass="12.0108"/>
+  <Type name="1645" class="CA" element="C" mass="12.0108"/>
+  <Type name="1646" class="N2" element="N" mass="14.0067"/>
+  <Type name="1648" class="NC" element="N" mass="14.0067"/>
+  <Type name="1649" class="C" element="C" mass="12.0108"/>
+  <Type name="1650" class="O" element="O" mass="15.9994"/>
+  <Type name="1651" class="CT" element="C" mass="12.0108"/>
+  <Type name="1653" class="CT" element="C" mass="12.0108"/>
+  <Type name="1655" class="OH" element="O" mass="15.9994"/>
+  <Type name="1657" class="OH" element="O" mass="15.9994"/>
+  <Type name="1660" class="OH" element="O" mass="15.9994"/>
+  <Type name="1661" class="CT" element="C" mass="12.0108"/>
+  <Type name="1663" class="CT" element="C" mass="12.0108"/>
+  <Type name="1665" class="OS" element="O" mass="15.9994"/>
+  <Type name="1666" class="CT" element="C" mass="12.0108"/>
+  <Type name="1668" class="N*" element="N" mass="14.0067"/>
+  <Type name="1669" class="CM" element="C" mass="12.0108"/>
+  <Type name="1671" class="CM" element="C" mass="12.0108"/>
+  <Type name="1673" class="CA" element="C" mass="12.0108"/>
+  <Type name="1674" class="N2" element="N" mass="14.0067"/>
+  <Type name="1676" class="NC" element="N" mass="14.0067"/>
+  <Type name="1677" class="C" element="C" mass="12.0108"/>
+  <Type name="1678" class="O" element="O" mass="15.9994"/>
+  <Type name="1679" class="CT" element="C" mass="12.0108"/>
+  <Type name="1681" class="CT" element="C" mass="12.0108"/>
+  <Type name="1683" class="OH" element="O" mass="15.9994"/>
+  <Type name="1685" class="OS" element="O" mass="15.9994"/>
+  <Type name="1687" class="OH" element="O" mass="15.9994"/>
+  <Type name="1688" class="CT" element="C" mass="12.0108"/>
+  <Type name="1690" class="CT" element="C" mass="12.0108"/>
+  <Type name="1692" class="OS" element="O" mass="15.9994"/>
+  <Type name="1693" class="CT" element="C" mass="12.0108"/>
+  <Type name="1695" class="N*" element="N" mass="14.0067"/>
+  <Type name="1696" class="CM" element="C" mass="12.0108"/>
+  <Type name="1698" class="CM" element="C" mass="12.0108"/>
+  <Type name="1700" class="CA" element="C" mass="12.0108"/>
+  <Type name="1701" class="N2" element="N" mass="14.0067"/>
+  <Type name="1703" class="NC" element="N" mass="14.0067"/>
+  <Type name="1704" class="C" element="C" mass="12.0108"/>
+  <Type name="1705" class="O" element="O" mass="15.9994"/>
+  <Type name="1706" class="CT" element="C" mass="12.0108"/>
+  <Type name="1708" class="CT" element="C" mass="12.0108"/>
+  <Type name="1710" class="OH" element="O" mass="15.9994"/>
+  <Type name="1712" class="OH" element="O" mass="15.9994"/>
+  <Type name="1714" class="P" element="P" mass="30.9738"/>
+  <Type name="1715" class="O2" element="O" mass="15.9994"/>
+  <Type name="1716" class="O2" element="O" mass="15.9994"/>
+  <Type name="1717" class="OS" element="O" mass="15.9994"/>
+  <Type name="1718" class="CT" element="C" mass="12.0108"/>
+  <Type name="1720" class="CT" element="C" mass="12.0108"/>
+  <Type name="1722" class="OS" element="O" mass="15.9994"/>
+  <Type name="1723" class="CT" element="C" mass="12.0108"/>
+  <Type name="1725" class="N*" element="N" mass="14.0067"/>
+  <Type name="1726" class="CK" element="C" mass="12.0108"/>
+  <Type name="1728" class="NB" element="N" mass="14.0067"/>
+  <Type name="1729" class="CB" element="C" mass="12.0108"/>
+  <Type name="1730" class="C" element="C" mass="12.0108"/>
+  <Type name="1731" class="O" element="O" mass="15.9994"/>
+  <Type name="1732" class="NA" element="N" mass="14.0067"/>
+  <Type name="1734" class="CA" element="C" mass="12.0108"/>
+  <Type name="1735" class="N2" element="N" mass="14.0067"/>
+  <Type name="1737" class="NC" element="N" mass="14.0067"/>
+  <Type name="1738" class="CB" element="C" mass="12.0108"/>
+  <Type name="1739" class="CT" element="C" mass="12.0108"/>
+  <Type name="1741" class="CT" element="C" mass="12.0108"/>
+  <Type name="1743" class="OH" element="O" mass="15.9994"/>
+  <Type name="1745" class="OS" element="O" mass="15.9994"/>
+  <Type name="1746" class="P" element="P" mass="30.9738"/>
+  <Type name="1747" class="O2" element="O" mass="15.9994"/>
+  <Type name="1748" class="O2" element="O" mass="15.9994"/>
+  <Type name="1749" class="OS" element="O" mass="15.9994"/>
+  <Type name="1750" class="CT" element="C" mass="12.0108"/>
+  <Type name="1752" class="CT" element="C" mass="12.0108"/>
+  <Type name="1754" class="OS" element="O" mass="15.9994"/>
+  <Type name="1755" class="CT" element="C" mass="12.0108"/>
+  <Type name="1757" class="N*" element="N" mass="14.0067"/>
+  <Type name="1758" class="CK" element="C" mass="12.0108"/>
+  <Type name="1760" class="NB" element="N" mass="14.0067"/>
+  <Type name="1761" class="CB" element="C" mass="12.0108"/>
+  <Type name="1762" class="C" element="C" mass="12.0108"/>
+  <Type name="1763" class="O" element="O" mass="15.9994"/>
+  <Type name="1764" class="NA" element="N" mass="14.0067"/>
+  <Type name="1766" class="CA" element="C" mass="12.0108"/>
+  <Type name="1767" class="N2" element="N" mass="14.0067"/>
+  <Type name="1769" class="NC" element="N" mass="14.0067"/>
+  <Type name="1770" class="CB" element="C" mass="12.0108"/>
+  <Type name="1771" class="CT" element="C" mass="12.0108"/>
+  <Type name="1773" class="CT" element="C" mass="12.0108"/>
+  <Type name="1775" class="OH" element="O" mass="15.9994"/>
+  <Type name="1777" class="OH" element="O" mass="15.9994"/>
+  <Type name="1780" class="OH" element="O" mass="15.9994"/>
+  <Type name="1781" class="CT" element="C" mass="12.0108"/>
+  <Type name="1783" class="CT" element="C" mass="12.0108"/>
+  <Type name="1785" class="OS" element="O" mass="15.9994"/>
+  <Type name="1786" class="CT" element="C" mass="12.0108"/>
+  <Type name="1788" class="N*" element="N" mass="14.0067"/>
+  <Type name="1789" class="CK" element="C" mass="12.0108"/>
+  <Type name="1791" class="NB" element="N" mass="14.0067"/>
+  <Type name="1792" class="CB" element="C" mass="12.0108"/>
+  <Type name="1793" class="C" element="C" mass="12.0108"/>
+  <Type name="1794" class="O" element="O" mass="15.9994"/>
+  <Type name="1795" class="NA" element="N" mass="14.0067"/>
+  <Type name="1797" class="CA" element="C" mass="12.0108"/>
+  <Type name="1798" class="N2" element="N" mass="14.0067"/>
+  <Type name="1800" class="NC" element="N" mass="14.0067"/>
+  <Type name="1801" class="CB" element="C" mass="12.0108"/>
+  <Type name="1802" class="CT" element="C" mass="12.0108"/>
+  <Type name="1804" class="CT" element="C" mass="12.0108"/>
+  <Type name="1806" class="OH" element="O" mass="15.9994"/>
+  <Type name="1808" class="OS" element="O" mass="15.9994"/>
+  <Type name="1810" class="OH" element="O" mass="15.9994"/>
+  <Type name="1811" class="CT" element="C" mass="12.0108"/>
+  <Type name="1813" class="CT" element="C" mass="12.0108"/>
+  <Type name="1815" class="OS" element="O" mass="15.9994"/>
+  <Type name="1816" class="CT" element="C" mass="12.0108"/>
+  <Type name="1818" class="N*" element="N" mass="14.0067"/>
+  <Type name="1819" class="CK" element="C" mass="12.0108"/>
+  <Type name="1821" class="NB" element="N" mass="14.0067"/>
+  <Type name="1822" class="CB" element="C" mass="12.0108"/>
+  <Type name="1823" class="C" element="C" mass="12.0108"/>
+  <Type name="1824" class="O" element="O" mass="15.9994"/>
+  <Type name="1825" class="NA" element="N" mass="14.0067"/>
+  <Type name="1827" class="CA" element="C" mass="12.0108"/>
+  <Type name="1828" class="N2" element="N" mass="14.0067"/>
+  <Type name="1830" class="NC" element="N" mass="14.0067"/>
+  <Type name="1831" class="CB" element="C" mass="12.0108"/>
+  <Type name="1832" class="CT" element="C" mass="12.0108"/>
+  <Type name="1834" class="CT" element="C" mass="12.0108"/>
+  <Type name="1836" class="OH" element="O" mass="15.9994"/>
+  <Type name="1838" class="OH" element="O" mass="15.9994"/>
+  <Type name="1840" class="P" element="P" mass="30.9738"/>
+  <Type name="1841" class="O2" element="O" mass="15.9994"/>
+  <Type name="1842" class="O2" element="O" mass="15.9994"/>
+  <Type name="1843" class="OS" element="O" mass="15.9994"/>
+  <Type name="1844" class="CT" element="C" mass="12.0108"/>
+  <Type name="1846" class="CT" element="C" mass="12.0108"/>
+  <Type name="1848" class="OS" element="O" mass="15.9994"/>
+  <Type name="1849" class="CT" element="C" mass="12.0108"/>
+  <Type name="1851" class="N*" element="N" mass="14.0067"/>
+  <Type name="1852" class="CM" element="C" mass="12.0108"/>
+  <Type name="1854" class="CM" element="C" mass="12.0108"/>
+  <Type name="1856" class="C" element="C" mass="12.0108"/>
+  <Type name="1857" class="O" element="O" mass="15.9994"/>
+  <Type name="1858" class="NA" element="N" mass="14.0067"/>
+  <Type name="1860" class="C" element="C" mass="12.0108"/>
+  <Type name="1861" class="O" element="O" mass="15.9994"/>
+  <Type name="1862" class="CT" element="C" mass="12.0108"/>
+  <Type name="1864" class="CT" element="C" mass="12.0108"/>
+  <Type name="1866" class="OH" element="O" mass="15.9994"/>
+  <Type name="1868" class="OS" element="O" mass="15.9994"/>
+  <Type name="1869" class="P" element="P" mass="30.9738"/>
+  <Type name="1870" class="O2" element="O" mass="15.9994"/>
+  <Type name="1871" class="O2" element="O" mass="15.9994"/>
+  <Type name="1872" class="OS" element="O" mass="15.9994"/>
+  <Type name="1873" class="CT" element="C" mass="12.0108"/>
+  <Type name="1875" class="CT" element="C" mass="12.0108"/>
+  <Type name="1877" class="OS" element="O" mass="15.9994"/>
+  <Type name="1878" class="CT" element="C" mass="12.0108"/>
+  <Type name="1880" class="N*" element="N" mass="14.0067"/>
+  <Type name="1881" class="CM" element="C" mass="12.0108"/>
+  <Type name="1883" class="CM" element="C" mass="12.0108"/>
+  <Type name="1885" class="C" element="C" mass="12.0108"/>
+  <Type name="1886" class="O" element="O" mass="15.9994"/>
+  <Type name="1887" class="NA" element="N" mass="14.0067"/>
+  <Type name="1889" class="C" element="C" mass="12.0108"/>
+  <Type name="1890" class="O" element="O" mass="15.9994"/>
+  <Type name="1891" class="CT" element="C" mass="12.0108"/>
+  <Type name="1893" class="CT" element="C" mass="12.0108"/>
+  <Type name="1895" class="OH" element="O" mass="15.9994"/>
+  <Type name="1897" class="OH" element="O" mass="15.9994"/>
+  <Type name="1900" class="OH" element="O" mass="15.9994"/>
+  <Type name="1901" class="CT" element="C" mass="12.0108"/>
+  <Type name="1903" class="CT" element="C" mass="12.0108"/>
+  <Type name="1905" class="OS" element="O" mass="15.9994"/>
+  <Type name="1906" class="CT" element="C" mass="12.0108"/>
+  <Type name="1908" class="N*" element="N" mass="14.0067"/>
+  <Type name="1909" class="CM" element="C" mass="12.0108"/>
+  <Type name="1911" class="CM" element="C" mass="12.0108"/>
+  <Type name="1913" class="C" element="C" mass="12.0108"/>
+  <Type name="1914" class="O" element="O" mass="15.9994"/>
+  <Type name="1915" class="NA" element="N" mass="14.0067"/>
+  <Type name="1917" class="C" element="C" mass="12.0108"/>
+  <Type name="1918" class="O" element="O" mass="15.9994"/>
+  <Type name="1919" class="CT" element="C" mass="12.0108"/>
+  <Type name="1921" class="CT" element="C" mass="12.0108"/>
+  <Type name="1923" class="OH" element="O" mass="15.9994"/>
+  <Type name="1925" class="OS" element="O" mass="15.9994"/>
+  <Type name="1927" class="OH" element="O" mass="15.9994"/>
+  <Type name="1928" class="CT" element="C" mass="12.0108"/>
+  <Type name="1930" class="CT" element="C" mass="12.0108"/>
+  <Type name="1932" class="OS" element="O" mass="15.9994"/>
+  <Type name="1933" class="CT" element="C" mass="12.0108"/>
+  <Type name="1935" class="N*" element="N" mass="14.0067"/>
+  <Type name="1936" class="CM" element="C" mass="12.0108"/>
+  <Type name="1938" class="CM" element="C" mass="12.0108"/>
+  <Type name="1940" class="C" element="C" mass="12.0108"/>
+  <Type name="1941" class="O" element="O" mass="15.9994"/>
+  <Type name="1942" class="NA" element="N" mass="14.0067"/>
+  <Type name="1944" class="C" element="C" mass="12.0108"/>
+  <Type name="1945" class="O" element="O" mass="15.9994"/>
+  <Type name="1946" class="CT" element="C" mass="12.0108"/>
+  <Type name="1948" class="CT" element="C" mass="12.0108"/>
+  <Type name="1950" class="OH" element="O" mass="15.9994"/>
+  <Type name="1952" class="OH" element="O" mass="15.9994"/>
+  <Type name="1954" class="IM" element="Cl" mass="35.4532"/>
+  <Type name="1955" class="Cs" element="Cs" mass="132.905"/>
+  <Type name="1956" class="K" element="K" mass="39.0983"/>
+  <Type name="1957" class="Li" element="Li" mass="6.9412"/>
+  <Type name="1958" class="MG" element="Mg" mass="24.3051"/>
+  <Type name="1959" class="IP" element="Na" mass="22.9898"/>
+  <Type name="1960" class="Rb" element="Rb" mass="85.4678"/>
+  <Type name="tip3p-O" class="OW" element="O" mass="15.9994"/>
  </AtomTypes>
  <Residues>
-  <Residue name="NMET">
-   <Atom name="N" type="909"/>
-   <Atom name="CA" type="911"/>
-   <Atom name="CB" type="913"/>
-   <Atom name="CG" type="915"/>
-   <Atom name="SD" type="917"/>
-   <Atom name="CE" type="918"/>
-   <Atom name="C" type="920"/>
-   <Atom name="O" type="921"/>
+  <Residue name="ACE">
+   <Atom name="CH3" type="711"/>
+   <Atom name="C" type="712"/>
+   <Atom name="O" type="713"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <ExternalBond from="1"/>
+  </Residue>
+  <Residue name="ALA">
+   <Atom name="N" type="0"/>
+   <Atom name="CA" type="2"/>
+   <Atom name="CB" type="4"/>
+   <Atom name="C" type="6"/>
+   <Atom name="O" type="7"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="3"/>
+   <Bond from="3" to="4"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="3"/>
+  </Residue>
+  <Residue name="ARG">
+   <Atom name="N" type="8"/>
+   <Atom name="CA" type="10"/>
+   <Atom name="CB" type="12"/>
+   <Atom name="CG" type="14"/>
+   <Atom name="CD" type="16"/>
+   <Atom name="NE" type="18"/>
+   <Atom name="CZ" type="20"/>
+   <Atom name="NH1" type="21"/>
+   <Atom name="NH2" type="23"/>
+   <Atom name="C" type="25"/>
+   <Atom name="O" type="26"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <Bond from="9" to="10"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="9"/>
+  </Residue>
+  <Residue name="ASN">
+   <Atom name="N" type="39"/>
+   <Atom name="CA" type="41"/>
+   <Atom name="CB" type="43"/>
+   <Atom name="CG" type="45"/>
+   <Atom name="OD1" type="46"/>
+   <Atom name="ND2" type="47"/>
+   <Atom name="C" type="49"/>
+   <Atom name="O" type="50"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
    <Bond from="1" to="6"/>
    <Bond from="2" to="3"/>
    <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="ASP">
+   <Atom name="N" type="51"/>
+   <Atom name="CA" type="53"/>
+   <Atom name="CB" type="55"/>
+   <Atom name="CG" type="57"/>
+   <Atom name="OD1" type="58"/>
+   <Atom name="OD2" type="59"/>
+   <Atom name="C" type="60"/>
+   <Atom name="O" type="61"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="CALA">
+   <Atom name="N" type="366"/>
+   <Atom name="CA" type="368"/>
+   <Atom name="CB" type="370"/>
+   <Atom name="C" type="372"/>
+   <Atom name="O" type="373"/>
+   <Atom name="OXT" type="374"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CARG">
+   <Atom name="N" type="375"/>
+   <Atom name="CA" type="377"/>
+   <Atom name="CB" type="379"/>
+   <Atom name="CG" type="381"/>
+   <Atom name="CD" type="383"/>
+   <Atom name="NE" type="385"/>
+   <Atom name="CZ" type="387"/>
+   <Atom name="NH1" type="388"/>
+   <Atom name="NH2" type="390"/>
+   <Atom name="C" type="392"/>
+   <Atom name="O" type="393"/>
+   <Atom name="OXT" type="394"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CASN">
+   <Atom name="N" type="395"/>
+   <Atom name="CA" type="397"/>
+   <Atom name="CB" type="399"/>
+   <Atom name="CG" type="401"/>
+   <Atom name="OD1" type="402"/>
+   <Atom name="ND2" type="403"/>
+   <Atom name="C" type="405"/>
+   <Atom name="O" type="406"/>
+   <Atom name="OXT" type="407"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CASP">
+   <Atom name="N" type="408"/>
+   <Atom name="CA" type="410"/>
+   <Atom name="CB" type="412"/>
+   <Atom name="CG" type="414"/>
+   <Atom name="OD1" type="415"/>
+   <Atom name="OD2" type="416"/>
+   <Atom name="C" type="417"/>
+   <Atom name="O" type="418"/>
+   <Atom name="OXT" type="419"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CCYS">
+   <Atom name="N" type="420"/>
+   <Atom name="CA" type="422"/>
+   <Atom name="CB" type="424"/>
+   <Atom name="SG" type="426"/>
+   <Atom name="C" type="428"/>
+   <Atom name="O" type="429"/>
+   <Atom name="OXT" type="430"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CCYX">
+   <Atom name="N" type="431"/>
+   <Atom name="CA" type="433"/>
+   <Atom name="CB" type="435"/>
+   <Atom name="SG" type="437"/>
+   <Atom name="C" type="438"/>
+   <Atom name="O" type="439"/>
+   <Atom name="OXT" type="440"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="3"/>
+  </Residue>
+  <Residue name="CGLN">
+   <Atom name="N" type="441"/>
+   <Atom name="CA" type="443"/>
+   <Atom name="CB" type="445"/>
+   <Atom name="CG" type="447"/>
+   <Atom name="CD" type="449"/>
+   <Atom name="OE1" type="450"/>
+   <Atom name="NE2" type="451"/>
+   <Atom name="C" type="453"/>
+   <Atom name="O" type="454"/>
+   <Atom name="OXT" type="455"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="9"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CGLU">
+   <Atom name="N" type="456"/>
+   <Atom name="CA" type="458"/>
+   <Atom name="CB" type="460"/>
+   <Atom name="CG" type="462"/>
+   <Atom name="CD" type="464"/>
+   <Atom name="OE1" type="465"/>
+   <Atom name="OE2" type="466"/>
+   <Atom name="C" type="467"/>
+   <Atom name="O" type="468"/>
+   <Atom name="OXT" type="469"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="9"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CGLY">
+   <Atom name="N" type="470"/>
+   <Atom name="CA" type="472"/>
+   <Atom name="C" type="474"/>
+   <Atom name="O" type="475"/>
+   <Atom name="OXT" type="476"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CHID">
+   <Atom name="N" type="477"/>
+   <Atom name="CA" type="479"/>
+   <Atom name="CB" type="481"/>
+   <Atom name="CG" type="483"/>
+   <Atom name="ND1" type="484"/>
+   <Atom name="CE1" type="486"/>
+   <Atom name="NE2" type="488"/>
+   <Atom name="CD2" type="489"/>
+   <Atom name="C" type="491"/>
+   <Atom name="O" type="492"/>
+   <Atom name="OXT" type="493"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CHIE">
+   <Atom name="N" type="494"/>
+   <Atom name="CA" type="496"/>
+   <Atom name="CB" type="498"/>
+   <Atom name="CG" type="500"/>
+   <Atom name="ND1" type="501"/>
+   <Atom name="CE1" type="502"/>
+   <Atom name="NE2" type="504"/>
+   <Atom name="CD2" type="506"/>
+   <Atom name="C" type="508"/>
+   <Atom name="O" type="509"/>
+   <Atom name="OXT" type="510"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CHIP">
+   <Atom name="N" type="511"/>
+   <Atom name="CA" type="513"/>
+   <Atom name="CB" type="515"/>
+   <Atom name="CG" type="517"/>
+   <Atom name="ND1" type="518"/>
+   <Atom name="CE1" type="520"/>
+   <Atom name="NE2" type="522"/>
+   <Atom name="CD2" type="524"/>
+   <Atom name="C" type="526"/>
+   <Atom name="O" type="527"/>
+   <Atom name="OXT" type="528"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CILE">
+   <Atom name="N" type="529"/>
+   <Atom name="CA" type="531"/>
+   <Atom name="CB" type="533"/>
+   <Atom name="CG2" type="535"/>
+   <Atom name="CG1" type="537"/>
+   <Atom name="CD1" type="539"/>
+   <Atom name="C" type="541"/>
+   <Atom name="O" type="542"/>
+   <Atom name="OXT" type="543"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
    <Bond from="4" to="5"/>
    <Bond from="6" to="7"/>
-   <ExternalBond from="6"/>
+   <Bond from="6" to="8"/>
+   <ExternalBond from="0"/>
   </Residue>
   <Residue name="CLEU">
    <Atom name="N" type="544"/>
@@ -1306,6 +1636,128 @@
    <Bond from="3" to="5"/>
    <Bond from="6" to="7"/>
    <Bond from="6" to="8"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CLYS">
+   <Atom name="N" type="559"/>
+   <Atom name="CA" type="561"/>
+   <Atom name="CB" type="563"/>
+   <Atom name="CG" type="565"/>
+   <Atom name="CD" type="567"/>
+   <Atom name="CE" type="569"/>
+   <Atom name="NZ" type="571"/>
+   <Atom name="C" type="573"/>
+   <Atom name="O" type="574"/>
+   <Atom name="OXT" type="575"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="9"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CMET">
+   <Atom name="N" type="576"/>
+   <Atom name="CA" type="578"/>
+   <Atom name="CB" type="580"/>
+   <Atom name="CG" type="582"/>
+   <Atom name="SD" type="584"/>
+   <Atom name="CE" type="585"/>
+   <Atom name="C" type="587"/>
+   <Atom name="O" type="588"/>
+   <Atom name="OXT" type="589"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CPHE">
+   <Atom name="N" type="590"/>
+   <Atom name="CA" type="592"/>
+   <Atom name="CB" type="594"/>
+   <Atom name="CG" type="596"/>
+   <Atom name="CD1" type="597"/>
+   <Atom name="CE1" type="599"/>
+   <Atom name="CZ" type="601"/>
+   <Atom name="CE2" type="603"/>
+   <Atom name="CD2" type="605"/>
+   <Atom name="C" type="607"/>
+   <Atom name="O" type="608"/>
+   <Atom name="OXT" type="609"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="8"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CPRO">
+   <Atom name="N" type="610"/>
+   <Atom name="CD" type="611"/>
+   <Atom name="CG" type="613"/>
+   <Atom name="CB" type="615"/>
+   <Atom name="CA" type="617"/>
+   <Atom name="C" type="619"/>
+   <Atom name="O" type="620"/>
+   <Atom name="OXT" type="621"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="4"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="7"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CSER">
+   <Atom name="N" type="622"/>
+   <Atom name="CA" type="624"/>
+   <Atom name="CB" type="626"/>
+   <Atom name="OG" type="628"/>
+   <Atom name="C" type="630"/>
+   <Atom name="O" type="631"/>
+   <Atom name="OXT" type="632"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CTHR">
+   <Atom name="N" type="633"/>
+   <Atom name="CA" type="635"/>
+   <Atom name="CB" type="637"/>
+   <Atom name="CG2" type="639"/>
+   <Atom name="OG1" type="641"/>
+   <Atom name="C" type="643"/>
+   <Atom name="O" type="644"/>
+   <Atom name="OXT" type="645"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="5"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="7"/>
    <ExternalBond from="0"/>
   </Residue>
   <Residue name="CTRP">
@@ -1342,6 +1794,387 @@
    <Bond from="12" to="14"/>
    <ExternalBond from="0"/>
   </Residue>
+  <Residue name="CTYR">
+   <Atom name="N" type="670"/>
+   <Atom name="CA" type="672"/>
+   <Atom name="CB" type="674"/>
+   <Atom name="CG" type="676"/>
+   <Atom name="CD1" type="677"/>
+   <Atom name="CE1" type="679"/>
+   <Atom name="CZ" type="681"/>
+   <Atom name="OH" type="682"/>
+   <Atom name="CE2" type="684"/>
+   <Atom name="CD2" type="686"/>
+   <Atom name="C" type="688"/>
+   <Atom name="O" type="689"/>
+   <Atom name="OXT" type="690"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="10"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="9"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="10" to="11"/>
+   <Bond from="10" to="12"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CVAL">
+   <Atom name="N" type="691"/>
+   <Atom name="CA" type="693"/>
+   <Atom name="CB" type="695"/>
+   <Atom name="CG1" type="697"/>
+   <Atom name="CG2" type="699"/>
+   <Atom name="C" type="701"/>
+   <Atom name="O" type="702"/>
+   <Atom name="OXT" type="703"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="5"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="7"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="CYS">
+   <Atom name="N" type="71"/>
+   <Atom name="CA" type="73"/>
+   <Atom name="CB" type="75"/>
+   <Atom name="SG" type="77"/>
+   <Atom name="C" type="79"/>
+   <Atom name="O" type="80"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="4"/>
+  </Residue>
+  <Residue name="CYX">
+   <Atom name="N" type="81"/>
+   <Atom name="CA" type="83"/>
+   <Atom name="CB" type="85"/>
+   <Atom name="SG" type="87"/>
+   <Atom name="C" type="88"/>
+   <Atom name="O" type="89"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="4"/>
+   <ExternalBond from="3"/>
+  </Residue>
+  <Residue name="Cl-">
+   <Atom name="Cl-" type="1954"/>
+  </Residue>
+  <Residue name="Cs+">
+   <Atom name="Cs+" type="1955"/>
+  </Residue>
+  <Residue name="DA">
+   <Atom name="P" type="1030"/>
+   <Atom name="O1P" type="1031"/>
+   <Atom name="O2P" type="1032"/>
+   <Atom name="O5'" type="1033"/>
+   <Atom name="C5'" type="1034"/>
+   <Atom name="C4'" type="1036"/>
+   <Atom name="O4'" type="1038"/>
+   <Atom name="C1'" type="1039"/>
+   <Atom name="N9" type="1041"/>
+   <Atom name="C8" type="1042"/>
+   <Atom name="N7" type="1044"/>
+   <Atom name="C5" type="1045"/>
+   <Atom name="C6" type="1046"/>
+   <Atom name="N6" type="1047"/>
+   <Atom name="N1" type="1049"/>
+   <Atom name="C2" type="1050"/>
+   <Atom name="N3" type="1052"/>
+   <Atom name="C4" type="1053"/>
+   <Atom name="C3'" type="1054"/>
+   <Atom name="C2'" type="1056"/>
+   <Atom name="O3'" type="1058"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="18"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="19"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="17"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="17"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="16" to="17"/>
+   <Bond from="18" to="19"/>
+   <Bond from="18" to="20"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="20"/>
+  </Residue>
+  <Residue name="DA3">
+   <Atom name="P" type="1059"/>
+   <Atom name="O1P" type="1060"/>
+   <Atom name="O2P" type="1061"/>
+   <Atom name="O5'" type="1062"/>
+   <Atom name="C5'" type="1063"/>
+   <Atom name="C4'" type="1065"/>
+   <Atom name="O4'" type="1067"/>
+   <Atom name="C1'" type="1068"/>
+   <Atom name="N9" type="1070"/>
+   <Atom name="C8" type="1071"/>
+   <Atom name="N7" type="1073"/>
+   <Atom name="C5" type="1074"/>
+   <Atom name="C6" type="1075"/>
+   <Atom name="N6" type="1076"/>
+   <Atom name="N1" type="1078"/>
+   <Atom name="C2" type="1079"/>
+   <Atom name="N3" type="1081"/>
+   <Atom name="C4" type="1082"/>
+   <Atom name="C3'" type="1083"/>
+   <Atom name="C2'" type="1085"/>
+   <Atom name="O3'" type="1087"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="18"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="19"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="17"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="17"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="16" to="17"/>
+   <Bond from="18" to="19"/>
+   <Bond from="18" to="20"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="DA5">
+   <Atom name="O5'" type="1090"/>
+   <Atom name="C5'" type="1091"/>
+   <Atom name="C4'" type="1093"/>
+   <Atom name="O4'" type="1095"/>
+   <Atom name="C1'" type="1096"/>
+   <Atom name="N9" type="1098"/>
+   <Atom name="C8" type="1099"/>
+   <Atom name="N7" type="1101"/>
+   <Atom name="C5" type="1102"/>
+   <Atom name="C6" type="1103"/>
+   <Atom name="N6" type="1104"/>
+   <Atom name="N1" type="1106"/>
+   <Atom name="C2" type="1107"/>
+   <Atom name="N3" type="1109"/>
+   <Atom name="C4" type="1110"/>
+   <Atom name="C3'" type="1111"/>
+   <Atom name="C2'" type="1113"/>
+   <Atom name="O3'" type="1115"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="15"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="16"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="14"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="15" to="16"/>
+   <Bond from="15" to="17"/>
+   <ExternalBond from="17"/>
+  </Residue>
+  <Residue name="DAN">
+   <Atom name="O5'" type="1117"/>
+   <Atom name="C5'" type="1118"/>
+   <Atom name="C4'" type="1120"/>
+   <Atom name="O4'" type="1122"/>
+   <Atom name="C1'" type="1123"/>
+   <Atom name="N9" type="1125"/>
+   <Atom name="C8" type="1126"/>
+   <Atom name="N7" type="1128"/>
+   <Atom name="C5" type="1129"/>
+   <Atom name="C6" type="1130"/>
+   <Atom name="N6" type="1131"/>
+   <Atom name="N1" type="1133"/>
+   <Atom name="C2" type="1134"/>
+   <Atom name="N3" type="1136"/>
+   <Atom name="C4" type="1137"/>
+   <Atom name="C3'" type="1138"/>
+   <Atom name="C2'" type="1140"/>
+   <Atom name="O3'" type="1142"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="15"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="16"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="14"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="15" to="16"/>
+   <Bond from="15" to="17"/>
+  </Residue>
+  <Residue name="DC">
+   <Atom name="P" type="1144"/>
+   <Atom name="O1P" type="1145"/>
+   <Atom name="O2P" type="1146"/>
+   <Atom name="O5'" type="1147"/>
+   <Atom name="C5'" type="1148"/>
+   <Atom name="C4'" type="1150"/>
+   <Atom name="O4'" type="1152"/>
+   <Atom name="C1'" type="1153"/>
+   <Atom name="N1" type="1155"/>
+   <Atom name="C6" type="1156"/>
+   <Atom name="C5" type="1158"/>
+   <Atom name="C4" type="1160"/>
+   <Atom name="N4" type="1161"/>
+   <Atom name="N3" type="1163"/>
+   <Atom name="C2" type="1164"/>
+   <Atom name="O2" type="1165"/>
+   <Atom name="C3'" type="1166"/>
+   <Atom name="C2'" type="1168"/>
+   <Atom name="O3'" type="1170"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="16"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="17"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="18"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="18"/>
+  </Residue>
+  <Residue name="DC3">
+   <Atom name="P" type="1171"/>
+   <Atom name="O1P" type="1172"/>
+   <Atom name="O2P" type="1173"/>
+   <Atom name="O5'" type="1174"/>
+   <Atom name="C5'" type="1175"/>
+   <Atom name="C4'" type="1177"/>
+   <Atom name="O4'" type="1179"/>
+   <Atom name="C1'" type="1180"/>
+   <Atom name="N1" type="1182"/>
+   <Atom name="C6" type="1183"/>
+   <Atom name="C5" type="1185"/>
+   <Atom name="C4" type="1187"/>
+   <Atom name="N4" type="1188"/>
+   <Atom name="N3" type="1190"/>
+   <Atom name="C2" type="1191"/>
+   <Atom name="O2" type="1192"/>
+   <Atom name="C3'" type="1193"/>
+   <Atom name="C2'" type="1195"/>
+   <Atom name="O3'" type="1197"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="16"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="17"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="18"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="DC5">
+   <Atom name="O5'" type="1200"/>
+   <Atom name="C5'" type="1201"/>
+   <Atom name="C4'" type="1203"/>
+   <Atom name="O4'" type="1205"/>
+   <Atom name="C1'" type="1206"/>
+   <Atom name="N1" type="1208"/>
+   <Atom name="C6" type="1209"/>
+   <Atom name="C5" type="1211"/>
+   <Atom name="C4" type="1213"/>
+   <Atom name="N4" type="1214"/>
+   <Atom name="N3" type="1216"/>
+   <Atom name="C2" type="1217"/>
+   <Atom name="O2" type="1218"/>
+   <Atom name="C3'" type="1219"/>
+   <Atom name="C2'" type="1221"/>
+   <Atom name="O3'" type="1223"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="13"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="14"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="11"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="13" to="14"/>
+   <Bond from="13" to="15"/>
+   <ExternalBond from="15"/>
+  </Residue>
   <Residue name="DCN">
    <Atom name="O5'" type="1225"/>
    <Atom name="C5'" type="1226"/>
@@ -1377,50 +2210,353 @@
    <Bond from="13" to="14"/>
    <Bond from="13" to="15"/>
   </Residue>
-  <Residue name="RU">
-   <Atom name="P" type="1840"/>
-   <Atom name="O1P" type="1841"/>
-   <Atom name="O2P" type="1842"/>
-   <Atom name="O5'" type="1843"/>
-   <Atom name="C5'" type="1844"/>
-   <Atom name="C4'" type="1846"/>
-   <Atom name="O4'" type="1848"/>
-   <Atom name="C1'" type="1849"/>
-   <Atom name="N1" type="1851"/>
-   <Atom name="C6" type="1852"/>
-   <Atom name="C5" type="1854"/>
-   <Atom name="C4" type="1856"/>
-   <Atom name="O4" type="1857"/>
-   <Atom name="N3" type="1858"/>
-   <Atom name="C2" type="1860"/>
-   <Atom name="O2" type="1861"/>
-   <Atom name="C3'" type="1862"/>
-   <Atom name="C2'" type="1864"/>
-   <Atom name="O2'" type="1866"/>
-   <Atom name="O3'" type="1868"/>
+  <Residue name="DG">
+   <Atom name="P" type="1250"/>
+   <Atom name="O1P" type="1251"/>
+   <Atom name="O2P" type="1252"/>
+   <Atom name="O5'" type="1253"/>
+   <Atom name="C5'" type="1254"/>
+   <Atom name="C4'" type="1256"/>
+   <Atom name="O4'" type="1258"/>
+   <Atom name="C1'" type="1259"/>
+   <Atom name="N9" type="1261"/>
+   <Atom name="C8" type="1262"/>
+   <Atom name="N7" type="1264"/>
+   <Atom name="C5" type="1265"/>
+   <Atom name="C6" type="1266"/>
+   <Atom name="O6" type="1267"/>
+   <Atom name="N1" type="1268"/>
+   <Atom name="C2" type="1270"/>
+   <Atom name="N2" type="1271"/>
+   <Atom name="N3" type="1273"/>
+   <Atom name="C4" type="1274"/>
+   <Atom name="C3'" type="1275"/>
+   <Atom name="C2'" type="1277"/>
+   <Atom name="O3'" type="1279"/>
    <Bond from="0" to="1"/>
    <Bond from="0" to="2"/>
    <Bond from="0" to="3"/>
    <Bond from="3" to="4"/>
    <Bond from="4" to="5"/>
    <Bond from="5" to="6"/>
-   <Bond from="5" to="16"/>
+   <Bond from="5" to="19"/>
    <Bond from="6" to="7"/>
    <Bond from="7" to="8"/>
-   <Bond from="7" to="17"/>
+   <Bond from="7" to="20"/>
    <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
+   <Bond from="8" to="18"/>
    <Bond from="9" to="10"/>
    <Bond from="10" to="11"/>
    <Bond from="11" to="12"/>
-   <Bond from="11" to="13"/>
-   <Bond from="13" to="14"/>
+   <Bond from="11" to="18"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="15" to="17"/>
+   <Bond from="17" to="18"/>
+   <Bond from="19" to="20"/>
+   <Bond from="19" to="21"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="21"/>
+  </Residue>
+  <Residue name="DG3">
+   <Atom name="P" type="1280"/>
+   <Atom name="O1P" type="1281"/>
+   <Atom name="O2P" type="1282"/>
+   <Atom name="O5'" type="1283"/>
+   <Atom name="C5'" type="1284"/>
+   <Atom name="C4'" type="1286"/>
+   <Atom name="O4'" type="1288"/>
+   <Atom name="C1'" type="1289"/>
+   <Atom name="N9" type="1291"/>
+   <Atom name="C8" type="1292"/>
+   <Atom name="N7" type="1294"/>
+   <Atom name="C5" type="1295"/>
+   <Atom name="C6" type="1296"/>
+   <Atom name="O6" type="1297"/>
+   <Atom name="N1" type="1298"/>
+   <Atom name="C2" type="1300"/>
+   <Atom name="N2" type="1301"/>
+   <Atom name="N3" type="1303"/>
+   <Atom name="C4" type="1304"/>
+   <Atom name="C3'" type="1305"/>
+   <Atom name="C2'" type="1307"/>
+   <Atom name="O3'" type="1309"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="19"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="20"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="18"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="18"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="15" to="17"/>
+   <Bond from="17" to="18"/>
+   <Bond from="19" to="20"/>
+   <Bond from="19" to="21"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="DG5">
+   <Atom name="O5'" type="1312"/>
+   <Atom name="C5'" type="1313"/>
+   <Atom name="C4'" type="1315"/>
+   <Atom name="O4'" type="1317"/>
+   <Atom name="C1'" type="1318"/>
+   <Atom name="N9" type="1320"/>
+   <Atom name="C8" type="1321"/>
+   <Atom name="N7" type="1323"/>
+   <Atom name="C5" type="1324"/>
+   <Atom name="C6" type="1325"/>
+   <Atom name="O6" type="1326"/>
+   <Atom name="N1" type="1327"/>
+   <Atom name="C2" type="1329"/>
+   <Atom name="N2" type="1330"/>
+   <Atom name="N3" type="1332"/>
+   <Atom name="C4" type="1333"/>
+   <Atom name="C3'" type="1334"/>
+   <Atom name="C2'" type="1336"/>
+   <Atom name="O3'" type="1338"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="16"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="17"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="15"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="15"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
    <Bond from="14" to="15"/>
    <Bond from="16" to="17"/>
-   <Bond from="16" to="19"/>
+   <Bond from="16" to="18"/>
+   <ExternalBond from="18"/>
+  </Residue>
+  <Residue name="DGN">
+   <Atom name="O5'" type="1340"/>
+   <Atom name="C5'" type="1341"/>
+   <Atom name="C4'" type="1343"/>
+   <Atom name="O4'" type="1345"/>
+   <Atom name="C1'" type="1346"/>
+   <Atom name="N9" type="1348"/>
+   <Atom name="C8" type="1349"/>
+   <Atom name="N7" type="1351"/>
+   <Atom name="C5" type="1352"/>
+   <Atom name="C6" type="1353"/>
+   <Atom name="O6" type="1354"/>
+   <Atom name="N1" type="1355"/>
+   <Atom name="C2" type="1357"/>
+   <Atom name="N2" type="1358"/>
+   <Atom name="N3" type="1360"/>
+   <Atom name="C4" type="1361"/>
+   <Atom name="C3'" type="1362"/>
+   <Atom name="C2'" type="1364"/>
+   <Atom name="O3'" type="1366"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="16"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="17"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="15"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="15"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="18"/>
+  </Residue>
+  <Residue name="DT">
+   <Atom name="P" type="1368"/>
+   <Atom name="O1P" type="1369"/>
+   <Atom name="O2P" type="1370"/>
+   <Atom name="O5'" type="1371"/>
+   <Atom name="C5'" type="1372"/>
+   <Atom name="C4'" type="1374"/>
+   <Atom name="O4'" type="1376"/>
+   <Atom name="C1'" type="1377"/>
+   <Atom name="N1" type="1379"/>
+   <Atom name="C6" type="1380"/>
+   <Atom name="C5" type="1382"/>
+   <Atom name="C7" type="1383"/>
+   <Atom name="C4" type="1385"/>
+   <Atom name="O4" type="1386"/>
+   <Atom name="N3" type="1387"/>
+   <Atom name="C2" type="1389"/>
+   <Atom name="O2" type="1390"/>
+   <Atom name="C3'" type="1391"/>
+   <Atom name="C2'" type="1393"/>
+   <Atom name="O3'" type="1395"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="17"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="18"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="15"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="10" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
    <Bond from="17" to="18"/>
+   <Bond from="17" to="19"/>
    <ExternalBond from="0"/>
    <ExternalBond from="19"/>
+  </Residue>
+  <Residue name="DT3">
+   <Atom name="P" type="1396"/>
+   <Atom name="O1P" type="1397"/>
+   <Atom name="O2P" type="1398"/>
+   <Atom name="O5'" type="1399"/>
+   <Atom name="C5'" type="1400"/>
+   <Atom name="C4'" type="1402"/>
+   <Atom name="O4'" type="1404"/>
+   <Atom name="C1'" type="1405"/>
+   <Atom name="N1" type="1407"/>
+   <Atom name="C6" type="1408"/>
+   <Atom name="C5" type="1410"/>
+   <Atom name="C7" type="1411"/>
+   <Atom name="C4" type="1413"/>
+   <Atom name="O4" type="1414"/>
+   <Atom name="N3" type="1415"/>
+   <Atom name="C2" type="1417"/>
+   <Atom name="O2" type="1418"/>
+   <Atom name="C3'" type="1419"/>
+   <Atom name="C2'" type="1421"/>
+   <Atom name="O3'" type="1423"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="17"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="18"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="15"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="10" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="17" to="18"/>
+   <Bond from="17" to="19"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="DT5">
+   <Atom name="O5'" type="1426"/>
+   <Atom name="C5'" type="1427"/>
+   <Atom name="C4'" type="1429"/>
+   <Atom name="O4'" type="1431"/>
+   <Atom name="C1'" type="1432"/>
+   <Atom name="N1" type="1434"/>
+   <Atom name="C6" type="1435"/>
+   <Atom name="C5" type="1437"/>
+   <Atom name="C7" type="1438"/>
+   <Atom name="C4" type="1440"/>
+   <Atom name="O4" type="1441"/>
+   <Atom name="N3" type="1442"/>
+   <Atom name="C2" type="1444"/>
+   <Atom name="O2" type="1445"/>
+   <Atom name="C3'" type="1446"/>
+   <Atom name="C2'" type="1448"/>
+   <Atom name="O3'" type="1450"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="14"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="15"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="12"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="9"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="14" to="15"/>
+   <Bond from="14" to="16"/>
+   <ExternalBond from="16"/>
+  </Residue>
+  <Residue name="DTN">
+   <Atom name="O5'" type="1452"/>
+   <Atom name="C5'" type="1453"/>
+   <Atom name="C4'" type="1455"/>
+   <Atom name="O4'" type="1457"/>
+   <Atom name="C1'" type="1458"/>
+   <Atom name="N1" type="1460"/>
+   <Atom name="C6" type="1461"/>
+   <Atom name="C5" type="1463"/>
+   <Atom name="C7" type="1464"/>
+   <Atom name="C4" type="1466"/>
+   <Atom name="O4" type="1467"/>
+   <Atom name="N3" type="1468"/>
+   <Atom name="C2" type="1470"/>
+   <Atom name="O2" type="1471"/>
+   <Atom name="C3'" type="1472"/>
+   <Atom name="C2'" type="1474"/>
+   <Atom name="O3'" type="1476"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="14"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="15"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="12"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="9"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="14" to="15"/>
+   <Bond from="14" to="16"/>
   </Residue>
   <Residue name="GLN">
    <Atom name="N" type="104"/>
@@ -1443,6 +2579,103 @@
    <ExternalBond from="0"/>
    <ExternalBond from="7"/>
   </Residue>
+  <Residue name="GLU">
+   <Atom name="N" type="118"/>
+   <Atom name="CA" type="120"/>
+   <Atom name="CB" type="122"/>
+   <Atom name="CG" type="124"/>
+   <Atom name="CD" type="126"/>
+   <Atom name="OE1" type="127"/>
+   <Atom name="OE2" type="128"/>
+   <Atom name="C" type="129"/>
+   <Atom name="O" type="130"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <Bond from="7" to="8"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="7"/>
+  </Residue>
+  <Residue name="GLY">
+   <Atom name="N" type="131"/>
+   <Atom name="CA" type="133"/>
+   <Atom name="C" type="135"/>
+   <Atom name="O" type="136"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="2"/>
+  </Residue>
+  <Residue name="HIP">
+   <Atom name="N" type="169"/>
+   <Atom name="CA" type="171"/>
+   <Atom name="CB" type="173"/>
+   <Atom name="CG" type="175"/>
+   <Atom name="ND1" type="176"/>
+   <Atom name="CE1" type="178"/>
+   <Atom name="NE2" type="180"/>
+   <Atom name="CD2" type="182"/>
+   <Atom name="C" type="184"/>
+   <Atom name="O" type="185"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="8"/>
+  </Residue>
+  <Residue name="ILE">
+   <Atom name="N" type="186"/>
+   <Atom name="CA" type="188"/>
+   <Atom name="CB" type="190"/>
+   <Atom name="CG2" type="192"/>
+   <Atom name="CG1" type="194"/>
+   <Atom name="CD1" type="196"/>
+   <Atom name="C" type="198"/>
+   <Atom name="O" type="199"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="K+">
+   <Atom name="K+" type="1956"/>
+  </Residue>
+  <Residue name="LEU">
+   <Atom name="N" type="200"/>
+   <Atom name="CA" type="202"/>
+   <Atom name="CB" type="204"/>
+   <Atom name="CG" type="206"/>
+   <Atom name="CD1" type="208"/>
+   <Atom name="CD2" type="210"/>
+   <Atom name="C" type="212"/>
+   <Atom name="O" type="213"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="6"/>
+  </Residue>
   <Residue name="LYS">
    <Atom name="N" type="230"/>
    <Atom name="CA" type="232"/>
@@ -1463,6 +2696,671 @@
    <Bond from="7" to="8"/>
    <ExternalBond from="0"/>
    <ExternalBond from="7"/>
+  </Residue>
+  <Residue name="Li+">
+   <Atom name="Li+" type="1957"/>
+  </Residue>
+  <Residue name="MET">
+   <Atom name="N" type="246"/>
+   <Atom name="CA" type="248"/>
+   <Atom name="CB" type="250"/>
+   <Atom name="CG" type="252"/>
+   <Atom name="SD" type="254"/>
+   <Atom name="CE" type="255"/>
+   <Atom name="C" type="257"/>
+   <Atom name="O" type="258"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="MG2">
+   <Atom name="MG" type="1958"/>
+  </Residue>
+  <Residue name="NALA">
+   <Atom name="N" type="714"/>
+   <Atom name="CA" type="716"/>
+   <Atom name="CB" type="718"/>
+   <Atom name="C" type="720"/>
+   <Atom name="O" type="721"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="3"/>
+   <Bond from="3" to="4"/>
+   <ExternalBond from="3"/>
+  </Residue>
+  <Residue name="NARG">
+   <Atom name="N" type="722"/>
+   <Atom name="CA" type="724"/>
+   <Atom name="CB" type="726"/>
+   <Atom name="CG" type="728"/>
+   <Atom name="CD" type="730"/>
+   <Atom name="NE" type="732"/>
+   <Atom name="CZ" type="734"/>
+   <Atom name="NH1" type="735"/>
+   <Atom name="NH2" type="737"/>
+   <Atom name="C" type="739"/>
+   <Atom name="O" type="740"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <Bond from="9" to="10"/>
+   <ExternalBond from="9"/>
+  </Residue>
+  <Residue name="NASN">
+   <Atom name="N" type="741"/>
+   <Atom name="CA" type="743"/>
+   <Atom name="CB" type="745"/>
+   <Atom name="CG" type="747"/>
+   <Atom name="OD1" type="748"/>
+   <Atom name="ND2" type="749"/>
+   <Atom name="C" type="751"/>
+   <Atom name="O" type="752"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="NASP">
+   <Atom name="N" type="753"/>
+   <Atom name="CA" type="755"/>
+   <Atom name="CB" type="757"/>
+   <Atom name="CG" type="759"/>
+   <Atom name="OD1" type="760"/>
+   <Atom name="OD2" type="761"/>
+   <Atom name="C" type="762"/>
+   <Atom name="O" type="763"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="NCYS">
+   <Atom name="N" type="764"/>
+   <Atom name="CA" type="766"/>
+   <Atom name="CB" type="768"/>
+   <Atom name="SG" type="770"/>
+   <Atom name="C" type="772"/>
+   <Atom name="O" type="773"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <ExternalBond from="4"/>
+  </Residue>
+  <Residue name="NCYX">
+   <Atom name="N" type="774"/>
+   <Atom name="CA" type="776"/>
+   <Atom name="CB" type="778"/>
+   <Atom name="SG" type="780"/>
+   <Atom name="C" type="781"/>
+   <Atom name="O" type="782"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <ExternalBond from="4"/>
+   <ExternalBond from="3"/>
+  </Residue>
+  <Residue name="NGLN">
+   <Atom name="N" type="783"/>
+   <Atom name="CA" type="785"/>
+   <Atom name="CB" type="787"/>
+   <Atom name="CG" type="789"/>
+   <Atom name="CD" type="791"/>
+   <Atom name="OE1" type="792"/>
+   <Atom name="NE2" type="793"/>
+   <Atom name="C" type="795"/>
+   <Atom name="O" type="796"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <Bond from="7" to="8"/>
+   <ExternalBond from="7"/>
+  </Residue>
+  <Residue name="NGLU">
+   <Atom name="N" type="797"/>
+   <Atom name="CA" type="799"/>
+   <Atom name="CB" type="801"/>
+   <Atom name="CG" type="803"/>
+   <Atom name="CD" type="805"/>
+   <Atom name="OE1" type="806"/>
+   <Atom name="OE2" type="807"/>
+   <Atom name="C" type="808"/>
+   <Atom name="O" type="809"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="6"/>
+   <Bond from="7" to="8"/>
+   <ExternalBond from="7"/>
+  </Residue>
+  <Residue name="NGLY">
+   <Atom name="N" type="810"/>
+   <Atom name="CA" type="812"/>
+   <Atom name="C" type="814"/>
+   <Atom name="O" type="815"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <ExternalBond from="2"/>
+  </Residue>
+  <Residue name="NHE">
+   <Atom name="N" type="704"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="NHID">
+   <Atom name="N" type="816"/>
+   <Atom name="CA" type="818"/>
+   <Atom name="CB" type="820"/>
+   <Atom name="CG" type="822"/>
+   <Atom name="ND1" type="823"/>
+   <Atom name="CE1" type="825"/>
+   <Atom name="NE2" type="827"/>
+   <Atom name="CD2" type="828"/>
+   <Atom name="C" type="830"/>
+   <Atom name="O" type="831"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <ExternalBond from="8"/>
+  </Residue>
+  <Residue name="NHIE">
+   <Atom name="N" type="832"/>
+   <Atom name="CA" type="834"/>
+   <Atom name="CB" type="836"/>
+   <Atom name="CG" type="838"/>
+   <Atom name="ND1" type="839"/>
+   <Atom name="CE1" type="840"/>
+   <Atom name="NE2" type="842"/>
+   <Atom name="CD2" type="844"/>
+   <Atom name="C" type="846"/>
+   <Atom name="O" type="847"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <ExternalBond from="8"/>
+  </Residue>
+  <Residue name="NHIP">
+   <Atom name="N" type="848"/>
+   <Atom name="CA" type="850"/>
+   <Atom name="CB" type="852"/>
+   <Atom name="CG" type="854"/>
+   <Atom name="ND1" type="855"/>
+   <Atom name="CE1" type="857"/>
+   <Atom name="NE2" type="859"/>
+   <Atom name="CD2" type="861"/>
+   <Atom name="C" type="863"/>
+   <Atom name="O" type="864"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="8"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="7"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="8" to="9"/>
+   <ExternalBond from="8"/>
+  </Residue>
+  <Residue name="NILE">
+   <Atom name="N" type="865"/>
+   <Atom name="CA" type="867"/>
+   <Atom name="CB" type="869"/>
+   <Atom name="CG2" type="871"/>
+   <Atom name="CG1" type="873"/>
+   <Atom name="CD1" type="875"/>
+   <Atom name="C" type="877"/>
+   <Atom name="O" type="878"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="NLEU">
+   <Atom name="N" type="879"/>
+   <Atom name="CA" type="881"/>
+   <Atom name="CB" type="883"/>
+   <Atom name="CG" type="885"/>
+   <Atom name="CD1" type="887"/>
+   <Atom name="CD2" type="889"/>
+   <Atom name="C" type="891"/>
+   <Atom name="O" type="892"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="NLYS">
+   <Atom name="N" type="893"/>
+   <Atom name="CA" type="895"/>
+   <Atom name="CB" type="897"/>
+   <Atom name="CG" type="899"/>
+   <Atom name="CD" type="901"/>
+   <Atom name="CE" type="903"/>
+   <Atom name="NZ" type="905"/>
+   <Atom name="C" type="907"/>
+   <Atom name="O" type="908"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="7"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="7" to="8"/>
+   <ExternalBond from="7"/>
+  </Residue>
+  <Residue name="NME">
+   <Atom name="N" type="706"/>
+   <Atom name="CH3" type="708"/>
+   <Bond from="0" to="1"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="NMET">
+   <Atom name="N" type="909"/>
+   <Atom name="CA" type="911"/>
+   <Atom name="CB" type="913"/>
+   <Atom name="CG" type="915"/>
+   <Atom name="SD" type="917"/>
+   <Atom name="CE" type="918"/>
+   <Atom name="C" type="920"/>
+   <Atom name="O" type="921"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="6"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="6" to="7"/>
+   <ExternalBond from="6"/>
+  </Residue>
+  <Residue name="NPHE">
+   <Atom name="N" type="922"/>
+   <Atom name="CA" type="924"/>
+   <Atom name="CB" type="926"/>
+   <Atom name="CG" type="928"/>
+   <Atom name="CD1" type="929"/>
+   <Atom name="CE1" type="931"/>
+   <Atom name="CZ" type="933"/>
+   <Atom name="CE2" type="935"/>
+   <Atom name="CD2" type="937"/>
+   <Atom name="C" type="939"/>
+   <Atom name="O" type="940"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="8"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="9" to="10"/>
+   <ExternalBond from="9"/>
+  </Residue>
+  <Residue name="NPRO">
+   <Atom name="N" type="941"/>
+   <Atom name="CD" type="943"/>
+   <Atom name="CG" type="945"/>
+   <Atom name="CB" type="947"/>
+   <Atom name="CA" type="949"/>
+   <Atom name="C" type="951"/>
+   <Atom name="O" type="952"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="4"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <ExternalBond from="5"/>
+  </Residue>
+  <Residue name="NSER">
+   <Atom name="N" type="953"/>
+   <Atom name="CA" type="955"/>
+   <Atom name="CB" type="957"/>
+   <Atom name="OG" type="959"/>
+   <Atom name="C" type="961"/>
+   <Atom name="O" type="962"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="4"/>
+   <Bond from="2" to="3"/>
+   <Bond from="4" to="5"/>
+   <ExternalBond from="4"/>
+  </Residue>
+  <Residue name="NTHR">
+   <Atom name="N" type="963"/>
+   <Atom name="CA" type="965"/>
+   <Atom name="CB" type="967"/>
+   <Atom name="CG2" type="969"/>
+   <Atom name="OG1" type="971"/>
+   <Atom name="C" type="973"/>
+   <Atom name="O" type="974"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="5"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="5" to="6"/>
+   <ExternalBond from="5"/>
+  </Residue>
+  <Residue name="NTRP">
+   <Atom name="N" type="975"/>
+   <Atom name="CA" type="977"/>
+   <Atom name="CB" type="979"/>
+   <Atom name="CG" type="981"/>
+   <Atom name="CD1" type="982"/>
+   <Atom name="NE1" type="984"/>
+   <Atom name="CE2" type="986"/>
+   <Atom name="CZ2" type="987"/>
+   <Atom name="CH2" type="989"/>
+   <Atom name="CZ3" type="991"/>
+   <Atom name="CE3" type="993"/>
+   <Atom name="CD2" type="995"/>
+   <Atom name="C" type="996"/>
+   <Atom name="O" type="997"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="12"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="11"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="11"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="12" to="13"/>
+   <ExternalBond from="12"/>
+  </Residue>
+  <Residue name="NTYR">
+   <Atom name="N" type="998"/>
+   <Atom name="CA" type="1000"/>
+   <Atom name="CB" type="1002"/>
+   <Atom name="CG" type="1004"/>
+   <Atom name="CD1" type="1005"/>
+   <Atom name="CE1" type="1007"/>
+   <Atom name="CZ" type="1009"/>
+   <Atom name="OH" type="1010"/>
+   <Atom name="CE2" type="1012"/>
+   <Atom name="CD2" type="1014"/>
+   <Atom name="C" type="1016"/>
+   <Atom name="O" type="1017"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="10"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="9"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="10" to="11"/>
+   <ExternalBond from="10"/>
+  </Residue>
+  <Residue name="NVAL">
+   <Atom name="N" type="1018"/>
+   <Atom name="CA" type="1020"/>
+   <Atom name="CB" type="1022"/>
+   <Atom name="CG1" type="1024"/>
+   <Atom name="CG2" type="1026"/>
+   <Atom name="C" type="1028"/>
+   <Atom name="O" type="1029"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="5"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="4"/>
+   <Bond from="5" to="6"/>
+   <ExternalBond from="5"/>
+  </Residue>
+  <Residue name="Na+">
+   <Atom name="Na+" type="1959"/>
+  </Residue>
+  <Residue name="PHE">
+   <Atom name="N" type="259"/>
+   <Atom name="CA" type="261"/>
+   <Atom name="CB" type="263"/>
+   <Atom name="CG" type="265"/>
+   <Atom name="CD1" type="266"/>
+   <Atom name="CE1" type="268"/>
+   <Atom name="CZ" type="270"/>
+   <Atom name="CE2" type="272"/>
+   <Atom name="CD2" type="274"/>
+   <Atom name="C" type="276"/>
+   <Atom name="O" type="277"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="9"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="8"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="9" to="10"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="9"/>
+  </Residue>
+  <Residue name="PRO">
+   <Atom name="N" type="278"/>
+   <Atom name="CD" type="279"/>
+   <Atom name="CG" type="281"/>
+   <Atom name="CB" type="283"/>
+   <Atom name="CA" type="285"/>
+   <Atom name="C" type="287"/>
+   <Atom name="O" type="288"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="4"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="5"/>
+  </Residue>
+  <Residue name="RA">
+   <Atom name="P" type="1478"/>
+   <Atom name="O1P" type="1479"/>
+   <Atom name="O2P" type="1480"/>
+   <Atom name="O5'" type="1481"/>
+   <Atom name="C5'" type="1482"/>
+   <Atom name="C4'" type="1484"/>
+   <Atom name="O4'" type="1486"/>
+   <Atom name="C1'" type="1487"/>
+   <Atom name="N9" type="1489"/>
+   <Atom name="C8" type="1490"/>
+   <Atom name="N7" type="1492"/>
+   <Atom name="C5" type="1493"/>
+   <Atom name="C6" type="1494"/>
+   <Atom name="N6" type="1495"/>
+   <Atom name="N1" type="1497"/>
+   <Atom name="C2" type="1498"/>
+   <Atom name="N3" type="1500"/>
+   <Atom name="C4" type="1501"/>
+   <Atom name="C3'" type="1502"/>
+   <Atom name="C2'" type="1504"/>
+   <Atom name="O2'" type="1506"/>
+   <Atom name="O3'" type="1508"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="18"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="19"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="17"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="17"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="16" to="17"/>
+   <Bond from="18" to="19"/>
+   <Bond from="18" to="21"/>
+   <Bond from="19" to="20"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="21"/>
+  </Residue>
+  <Residue name="RA3">
+   <Atom name="P" type="1509"/>
+   <Atom name="O1P" type="1510"/>
+   <Atom name="O2P" type="1511"/>
+   <Atom name="O5'" type="1512"/>
+   <Atom name="C5'" type="1513"/>
+   <Atom name="C4'" type="1515"/>
+   <Atom name="O4'" type="1517"/>
+   <Atom name="C1'" type="1518"/>
+   <Atom name="N9" type="1520"/>
+   <Atom name="C8" type="1521"/>
+   <Atom name="N7" type="1523"/>
+   <Atom name="C5" type="1524"/>
+   <Atom name="C6" type="1525"/>
+   <Atom name="N6" type="1526"/>
+   <Atom name="N1" type="1528"/>
+   <Atom name="C2" type="1529"/>
+   <Atom name="N3" type="1531"/>
+   <Atom name="C4" type="1532"/>
+   <Atom name="C3'" type="1533"/>
+   <Atom name="C2'" type="1535"/>
+   <Atom name="O2'" type="1537"/>
+   <Atom name="O3'" type="1539"/>
+   <Bond from="0" to="1"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="18"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="19"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="17"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="17"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="15" to="16"/>
+   <Bond from="16" to="17"/>
+   <Bond from="18" to="19"/>
+   <Bond from="18" to="21"/>
+   <Bond from="19" to="20"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="RA5">
+   <Atom name="O5'" type="1542"/>
+   <Atom name="C5'" type="1543"/>
+   <Atom name="C4'" type="1545"/>
+   <Atom name="O4'" type="1547"/>
+   <Atom name="C1'" type="1548"/>
+   <Atom name="N9" type="1550"/>
+   <Atom name="C8" type="1551"/>
+   <Atom name="N7" type="1553"/>
+   <Atom name="C5" type="1554"/>
+   <Atom name="C6" type="1555"/>
+   <Atom name="N6" type="1556"/>
+   <Atom name="N1" type="1558"/>
+   <Atom name="C2" type="1559"/>
+   <Atom name="N3" type="1561"/>
+   <Atom name="C4" type="1562"/>
+   <Atom name="C3'" type="1563"/>
+   <Atom name="C2'" type="1565"/>
+   <Atom name="O2'" type="1567"/>
+   <Atom name="O3'" type="1569"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="15"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="16"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="14"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="15" to="16"/>
+   <Bond from="15" to="18"/>
+   <Bond from="16" to="17"/>
+   <ExternalBond from="18"/>
   </Residue>
   <Residue name="RAN">
    <Atom name="O5'" type="1571"/>
@@ -1506,81 +3404,169 @@
    <Bond from="15" to="18"/>
    <Bond from="16" to="17"/>
   </Residue>
-  <Residue name="PRO">
-   <Atom name="N" type="278"/>
-   <Atom name="CD" type="279"/>
-   <Atom name="CG" type="281"/>
-   <Atom name="CB" type="283"/>
-   <Atom name="CA" type="285"/>
-   <Atom name="C" type="287"/>
-   <Atom name="O" type="288"/>
+  <Residue name="RC">
+   <Atom name="P" type="1600"/>
+   <Atom name="O1P" type="1601"/>
+   <Atom name="O2P" type="1602"/>
+   <Atom name="O5'" type="1603"/>
+   <Atom name="C5'" type="1604"/>
+   <Atom name="C4'" type="1606"/>
+   <Atom name="O4'" type="1608"/>
+   <Atom name="C1'" type="1609"/>
+   <Atom name="N1" type="1611"/>
+   <Atom name="C6" type="1612"/>
+   <Atom name="C5" type="1614"/>
+   <Atom name="C4" type="1616"/>
+   <Atom name="N4" type="1617"/>
+   <Atom name="N3" type="1619"/>
+   <Atom name="C2" type="1620"/>
+   <Atom name="O2" type="1621"/>
+   <Atom name="C3'" type="1622"/>
+   <Atom name="C2'" type="1624"/>
+   <Atom name="O2'" type="1626"/>
+   <Atom name="O3'" type="1628"/>
    <Bond from="0" to="1"/>
-   <Bond from="0" to="4"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
    <Bond from="3" to="4"/>
    <Bond from="4" to="5"/>
    <Bond from="5" to="6"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="NGLN">
-   <Atom name="N" type="783"/>
-   <Atom name="CA" type="785"/>
-   <Atom name="CB" type="787"/>
-   <Atom name="CG" type="789"/>
-   <Atom name="CD" type="791"/>
-   <Atom name="OE1" type="792"/>
-   <Atom name="NE2" type="793"/>
-   <Atom name="C" type="795"/>
-   <Atom name="O" type="796"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <Bond from="7" to="8"/>
-   <ExternalBond from="7"/>
-  </Residue>
-  <Residue name="NILE">
-   <Atom name="N" type="865"/>
-   <Atom name="CA" type="867"/>
-   <Atom name="CB" type="869"/>
-   <Atom name="CG2" type="871"/>
-   <Atom name="CG1" type="873"/>
-   <Atom name="CD1" type="875"/>
-   <Atom name="C" type="877"/>
-   <Atom name="O" type="878"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="4" to="5"/>
+   <Bond from="5" to="16"/>
    <Bond from="6" to="7"/>
-   <ExternalBond from="6"/>
+   <Bond from="7" to="8"/>
+   <Bond from="7" to="17"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="19"/>
+   <Bond from="17" to="18"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="19"/>
   </Residue>
-  <Residue name="NGLU">
-   <Atom name="N" type="797"/>
-   <Atom name="CA" type="799"/>
-   <Atom name="CB" type="801"/>
-   <Atom name="CG" type="803"/>
-   <Atom name="CD" type="805"/>
-   <Atom name="OE1" type="806"/>
-   <Atom name="OE2" type="807"/>
-   <Atom name="C" type="808"/>
-   <Atom name="O" type="809"/>
+  <Residue name="RC3">
+   <Atom name="P" type="1629"/>
+   <Atom name="O1P" type="1630"/>
+   <Atom name="O2P" type="1631"/>
+   <Atom name="O5'" type="1632"/>
+   <Atom name="C5'" type="1633"/>
+   <Atom name="C4'" type="1635"/>
+   <Atom name="O4'" type="1637"/>
+   <Atom name="C1'" type="1638"/>
+   <Atom name="N1" type="1640"/>
+   <Atom name="C6" type="1641"/>
+   <Atom name="C5" type="1643"/>
+   <Atom name="C4" type="1645"/>
+   <Atom name="N4" type="1646"/>
+   <Atom name="N3" type="1648"/>
+   <Atom name="C2" type="1649"/>
+   <Atom name="O2" type="1650"/>
+   <Atom name="C3'" type="1651"/>
+   <Atom name="C2'" type="1653"/>
+   <Atom name="O2'" type="1655"/>
+   <Atom name="O3'" type="1657"/>
    <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
+   <Bond from="0" to="2"/>
+   <Bond from="0" to="3"/>
    <Bond from="3" to="4"/>
    <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="16"/>
+   <Bond from="6" to="7"/>
    <Bond from="7" to="8"/>
-   <ExternalBond from="7"/>
+   <Bond from="7" to="17"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="14"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="11" to="13"/>
+   <Bond from="13" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="19"/>
+   <Bond from="17" to="18"/>
+   <ExternalBond from="0"/>
+  </Residue>
+  <Residue name="RC5">
+   <Atom name="O5'" type="1660"/>
+   <Atom name="C5'" type="1661"/>
+   <Atom name="C4'" type="1663"/>
+   <Atom name="O4'" type="1665"/>
+   <Atom name="C1'" type="1666"/>
+   <Atom name="N1" type="1668"/>
+   <Atom name="C6" type="1669"/>
+   <Atom name="C5" type="1671"/>
+   <Atom name="C4" type="1673"/>
+   <Atom name="N4" type="1674"/>
+   <Atom name="N3" type="1676"/>
+   <Atom name="C2" type="1677"/>
+   <Atom name="O2" type="1678"/>
+   <Atom name="C3'" type="1679"/>
+   <Atom name="C2'" type="1681"/>
+   <Atom name="O2'" type="1683"/>
+   <Atom name="O3'" type="1685"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="13"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="14"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="11"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="13" to="14"/>
+   <Bond from="13" to="16"/>
+   <Bond from="14" to="15"/>
+   <ExternalBond from="16"/>
+  </Residue>
+  <Residue name="RCN">
+   <Atom name="O5'" type="1687"/>
+   <Atom name="C5'" type="1688"/>
+   <Atom name="C4'" type="1690"/>
+   <Atom name="O4'" type="1692"/>
+   <Atom name="C1'" type="1693"/>
+   <Atom name="N1" type="1695"/>
+   <Atom name="C6" type="1696"/>
+   <Atom name="C5" type="1698"/>
+   <Atom name="C4" type="1700"/>
+   <Atom name="N4" type="1701"/>
+   <Atom name="N3" type="1703"/>
+   <Atom name="C2" type="1704"/>
+   <Atom name="O2" type="1705"/>
+   <Atom name="C3'" type="1706"/>
+   <Atom name="C2'" type="1708"/>
+   <Atom name="O2'" type="1710"/>
+   <Atom name="O3'" type="1712"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="2" to="3"/>
+   <Bond from="2" to="13"/>
+   <Bond from="3" to="4"/>
+   <Bond from="4" to="5"/>
+   <Bond from="4" to="14"/>
+   <Bond from="5" to="6"/>
+   <Bond from="5" to="11"/>
+   <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="13" to="14"/>
+   <Bond from="13" to="16"/>
+   <Bond from="14" to="15"/>
   </Residue>
   <Residue name="RG">
    <Atom name="P" type="1714"/>
@@ -1633,872 +3619,6 @@
    <Bond from="20" to="21"/>
    <ExternalBond from="0"/>
    <ExternalBond from="22"/>
-  </Residue>
-  <Residue name="RA">
-   <Atom name="P" type="1478"/>
-   <Atom name="O1P" type="1479"/>
-   <Atom name="O2P" type="1480"/>
-   <Atom name="O5'" type="1481"/>
-   <Atom name="C5'" type="1482"/>
-   <Atom name="C4'" type="1484"/>
-   <Atom name="O4'" type="1486"/>
-   <Atom name="C1'" type="1487"/>
-   <Atom name="N9" type="1489"/>
-   <Atom name="C8" type="1490"/>
-   <Atom name="N7" type="1492"/>
-   <Atom name="C5" type="1493"/>
-   <Atom name="C6" type="1494"/>
-   <Atom name="N6" type="1495"/>
-   <Atom name="N1" type="1497"/>
-   <Atom name="C2" type="1498"/>
-   <Atom name="N3" type="1500"/>
-   <Atom name="C4" type="1501"/>
-   <Atom name="C3'" type="1502"/>
-   <Atom name="C2'" type="1504"/>
-   <Atom name="O2'" type="1506"/>
-   <Atom name="O3'" type="1508"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="18"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="19"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="17"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="17"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="16" to="17"/>
-   <Bond from="18" to="19"/>
-   <Bond from="18" to="21"/>
-   <Bond from="19" to="20"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="21"/>
-  </Residue>
-  <Residue name="RC">
-   <Atom name="P" type="1600"/>
-   <Atom name="O1P" type="1601"/>
-   <Atom name="O2P" type="1602"/>
-   <Atom name="O5'" type="1603"/>
-   <Atom name="C5'" type="1604"/>
-   <Atom name="C4'" type="1606"/>
-   <Atom name="O4'" type="1608"/>
-   <Atom name="C1'" type="1609"/>
-   <Atom name="N1" type="1611"/>
-   <Atom name="C6" type="1612"/>
-   <Atom name="C5" type="1614"/>
-   <Atom name="C4" type="1616"/>
-   <Atom name="N4" type="1617"/>
-   <Atom name="N3" type="1619"/>
-   <Atom name="C2" type="1620"/>
-   <Atom name="O2" type="1621"/>
-   <Atom name="C3'" type="1622"/>
-   <Atom name="C2'" type="1624"/>
-   <Atom name="O2'" type="1626"/>
-   <Atom name="O3'" type="1628"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="16"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="17"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="19"/>
-   <Bond from="17" to="18"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="19"/>
-  </Residue>
-  <Residue name="NLEU">
-   <Atom name="N" type="879"/>
-   <Atom name="CA" type="881"/>
-   <Atom name="CB" type="883"/>
-   <Atom name="CG" type="885"/>
-   <Atom name="CD1" type="887"/>
-   <Atom name="CD2" type="889"/>
-   <Atom name="C" type="891"/>
-   <Atom name="O" type="892"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="NGLY">
-   <Atom name="N" type="810"/>
-   <Atom name="CA" type="812"/>
-   <Atom name="C" type="814"/>
-   <Atom name="O" type="815"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <ExternalBond from="2"/>
-  </Residue>
-  <Residue name="NPRO">
-   <Atom name="N" type="941"/>
-   <Atom name="CD" type="943"/>
-   <Atom name="CG" type="945"/>
-   <Atom name="CB" type="947"/>
-   <Atom name="CA" type="949"/>
-   <Atom name="C" type="951"/>
-   <Atom name="O" type="952"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="4"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="VAL">
-   <Atom name="N" type="354"/>
-   <Atom name="CA" type="356"/>
-   <Atom name="CB" type="358"/>
-   <Atom name="CG1" type="360"/>
-   <Atom name="CG2" type="362"/>
-   <Atom name="C" type="364"/>
-   <Atom name="O" type="365"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="THR">
-   <Atom name="N" type="299"/>
-   <Atom name="CA" type="301"/>
-   <Atom name="CB" type="303"/>
-   <Atom name="CG2" type="305"/>
-   <Atom name="OG1" type="307"/>
-   <Atom name="C" type="309"/>
-   <Atom name="O" type="310"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="RA5">
-   <Atom name="O5'" type="1542"/>
-   <Atom name="C5'" type="1543"/>
-   <Atom name="C4'" type="1545"/>
-   <Atom name="O4'" type="1547"/>
-   <Atom name="C1'" type="1548"/>
-   <Atom name="N9" type="1550"/>
-   <Atom name="C8" type="1551"/>
-   <Atom name="N7" type="1553"/>
-   <Atom name="C5" type="1554"/>
-   <Atom name="C6" type="1555"/>
-   <Atom name="N6" type="1556"/>
-   <Atom name="N1" type="1558"/>
-   <Atom name="C2" type="1559"/>
-   <Atom name="N3" type="1561"/>
-   <Atom name="C4" type="1562"/>
-   <Atom name="C3'" type="1563"/>
-   <Atom name="C2'" type="1565"/>
-   <Atom name="O2'" type="1567"/>
-   <Atom name="O3'" type="1569"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="15"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="16"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="14"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="15" to="16"/>
-   <Bond from="15" to="18"/>
-   <Bond from="16" to="17"/>
-   <ExternalBond from="18"/>
-  </Residue>
-  <Residue name="RA3">
-   <Atom name="P" type="1509"/>
-   <Atom name="O1P" type="1510"/>
-   <Atom name="O2P" type="1511"/>
-   <Atom name="O5'" type="1512"/>
-   <Atom name="C5'" type="1513"/>
-   <Atom name="C4'" type="1515"/>
-   <Atom name="O4'" type="1517"/>
-   <Atom name="C1'" type="1518"/>
-   <Atom name="N9" type="1520"/>
-   <Atom name="C8" type="1521"/>
-   <Atom name="N7" type="1523"/>
-   <Atom name="C5" type="1524"/>
-   <Atom name="C6" type="1525"/>
-   <Atom name="N6" type="1526"/>
-   <Atom name="N1" type="1528"/>
-   <Atom name="C2" type="1529"/>
-   <Atom name="N3" type="1531"/>
-   <Atom name="C4" type="1532"/>
-   <Atom name="C3'" type="1533"/>
-   <Atom name="C2'" type="1535"/>
-   <Atom name="O2'" type="1537"/>
-   <Atom name="O3'" type="1539"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="18"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="19"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="17"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="17"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="16" to="17"/>
-   <Bond from="18" to="19"/>
-   <Bond from="18" to="21"/>
-   <Bond from="19" to="20"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NVAL">
-   <Atom name="N" type="1018"/>
-   <Atom name="CA" type="1020"/>
-   <Atom name="CB" type="1022"/>
-   <Atom name="CG1" type="1024"/>
-   <Atom name="CG2" type="1026"/>
-   <Atom name="C" type="1028"/>
-   <Atom name="O" type="1029"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="DC5">
-   <Atom name="O5'" type="1200"/>
-   <Atom name="C5'" type="1201"/>
-   <Atom name="C4'" type="1203"/>
-   <Atom name="O4'" type="1205"/>
-   <Atom name="C1'" type="1206"/>
-   <Atom name="N1" type="1208"/>
-   <Atom name="C6" type="1209"/>
-   <Atom name="C5" type="1211"/>
-   <Atom name="C4" type="1213"/>
-   <Atom name="N4" type="1214"/>
-   <Atom name="N3" type="1216"/>
-   <Atom name="C2" type="1217"/>
-   <Atom name="O2" type="1218"/>
-   <Atom name="C3'" type="1219"/>
-   <Atom name="C2'" type="1221"/>
-   <Atom name="O3'" type="1223"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="13"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="14"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="11"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="13" to="14"/>
-   <Bond from="13" to="15"/>
-   <ExternalBond from="15"/>
-  </Residue>
-  <Residue name="DC3">
-   <Atom name="P" type="1171"/>
-   <Atom name="O1P" type="1172"/>
-   <Atom name="O2P" type="1173"/>
-   <Atom name="O5'" type="1174"/>
-   <Atom name="C5'" type="1175"/>
-   <Atom name="C4'" type="1177"/>
-   <Atom name="O4'" type="1179"/>
-   <Atom name="C1'" type="1180"/>
-   <Atom name="N1" type="1182"/>
-   <Atom name="C6" type="1183"/>
-   <Atom name="C5" type="1185"/>
-   <Atom name="C4" type="1187"/>
-   <Atom name="N4" type="1188"/>
-   <Atom name="N3" type="1190"/>
-   <Atom name="C2" type="1191"/>
-   <Atom name="O2" type="1192"/>
-   <Atom name="C3'" type="1193"/>
-   <Atom name="C2'" type="1195"/>
-   <Atom name="O3'" type="1197"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="16"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="17"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="18"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NTRP">
-   <Atom name="N" type="975"/>
-   <Atom name="CA" type="977"/>
-   <Atom name="CB" type="979"/>
-   <Atom name="CG" type="981"/>
-   <Atom name="CD1" type="982"/>
-   <Atom name="NE1" type="984"/>
-   <Atom name="CE2" type="986"/>
-   <Atom name="CZ2" type="987"/>
-   <Atom name="CH2" type="989"/>
-   <Atom name="CZ3" type="991"/>
-   <Atom name="CE3" type="993"/>
-   <Atom name="CD2" type="995"/>
-   <Atom name="C" type="996"/>
-   <Atom name="O" type="997"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="12"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="11"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="11"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="12" to="13"/>
-   <ExternalBond from="12"/>
-  </Residue>
-  <Residue name="PHE">
-   <Atom name="N" type="259"/>
-   <Atom name="CA" type="261"/>
-   <Atom name="CB" type="263"/>
-   <Atom name="CG" type="265"/>
-   <Atom name="CD1" type="266"/>
-   <Atom name="CE1" type="268"/>
-   <Atom name="CZ" type="270"/>
-   <Atom name="CE2" type="272"/>
-   <Atom name="CD2" type="274"/>
-   <Atom name="C" type="276"/>
-   <Atom name="O" type="277"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="8"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="9" to="10"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="9"/>
-  </Residue>
-  <Residue name="NCYS">
-   <Atom name="N" type="764"/>
-   <Atom name="CA" type="766"/>
-   <Atom name="CB" type="768"/>
-   <Atom name="SG" type="770"/>
-   <Atom name="C" type="772"/>
-   <Atom name="O" type="773"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="4"/>
-   <Bond from="2" to="3"/>
-   <Bond from="4" to="5"/>
-   <ExternalBond from="4"/>
-  </Residue>
-  <Residue name="TYR">
-   <Atom name="N" type="334"/>
-   <Atom name="CA" type="336"/>
-   <Atom name="CB" type="338"/>
-   <Atom name="CG" type="340"/>
-   <Atom name="CD1" type="341"/>
-   <Atom name="CE1" type="343"/>
-   <Atom name="CZ" type="345"/>
-   <Atom name="OH" type="346"/>
-   <Atom name="CE2" type="348"/>
-   <Atom name="CD2" type="350"/>
-   <Atom name="C" type="352"/>
-   <Atom name="O" type="353"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="10"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="9"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="10" to="11"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="10"/>
-  </Residue>
-  <Residue name="NTHR">
-   <Atom name="N" type="963"/>
-   <Atom name="CA" type="965"/>
-   <Atom name="CB" type="967"/>
-   <Atom name="CG2" type="969"/>
-   <Atom name="OG1" type="971"/>
-   <Atom name="C" type="973"/>
-   <Atom name="O" type="974"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <ExternalBond from="5"/>
-  </Residue>
-  <Residue name="DTN">
-   <Atom name="O5'" type="1452"/>
-   <Atom name="C5'" type="1453"/>
-   <Atom name="C4'" type="1455"/>
-   <Atom name="O4'" type="1457"/>
-   <Atom name="C1'" type="1458"/>
-   <Atom name="N1" type="1460"/>
-   <Atom name="C6" type="1461"/>
-   <Atom name="C5" type="1463"/>
-   <Atom name="C7" type="1464"/>
-   <Atom name="C4" type="1466"/>
-   <Atom name="O4" type="1467"/>
-   <Atom name="N3" type="1468"/>
-   <Atom name="C2" type="1470"/>
-   <Atom name="O2" type="1471"/>
-   <Atom name="C3'" type="1472"/>
-   <Atom name="C2'" type="1474"/>
-   <Atom name="O3'" type="1476"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="14"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="15"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="12"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="9"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="14" to="15"/>
-   <Bond from="14" to="16"/>
-  </Residue>
-  <Residue name="CPHE">
-   <Atom name="N" type="590"/>
-   <Atom name="CA" type="592"/>
-   <Atom name="CB" type="594"/>
-   <Atom name="CG" type="596"/>
-   <Atom name="CD1" type="597"/>
-   <Atom name="CE1" type="599"/>
-   <Atom name="CZ" type="601"/>
-   <Atom name="CE2" type="603"/>
-   <Atom name="CD2" type="605"/>
-   <Atom name="C" type="607"/>
-   <Atom name="O" type="608"/>
-   <Atom name="OXT" type="609"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="8"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NHIS">
-   <Atom name="N" type="816"/>
-   <Atom name="CA" type="818"/>
-   <Atom name="CB" type="820"/>
-   <Atom name="CG" type="822"/>
-   <Atom name="ND1" type="823"/>
-   <Atom name="CE1" type="825"/>
-   <Atom name="NE2" type="827"/>
-   <Atom name="CD2" type="828"/>
-   <Atom name="C" type="830"/>
-   <Atom name="O" type="831"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <ExternalBond from="8"/>
-  </Residue>
-  <Residue name="MG2">
-   <Atom name="MG" type="1958"/>
-  </Residue>
-  <Residue name="NHE">
-   <Atom name="N" type="704"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NLYS">
-   <Atom name="N" type="893"/>
-   <Atom name="CA" type="895"/>
-   <Atom name="CB" type="897"/>
-   <Atom name="CG" type="899"/>
-   <Atom name="CD" type="901"/>
-   <Atom name="CE" type="903"/>
-   <Atom name="NZ" type="905"/>
-   <Atom name="C" type="907"/>
-   <Atom name="O" type="908"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="7" to="8"/>
-   <ExternalBond from="7"/>
-  </Residue>
-  <Residue name="RGN">
-   <Atom name="O5'" type="1810"/>
-   <Atom name="C5'" type="1811"/>
-   <Atom name="C4'" type="1813"/>
-   <Atom name="O4'" type="1815"/>
-   <Atom name="C1'" type="1816"/>
-   <Atom name="N9" type="1818"/>
-   <Atom name="C8" type="1819"/>
-   <Atom name="N7" type="1821"/>
-   <Atom name="C5" type="1822"/>
-   <Atom name="C6" type="1823"/>
-   <Atom name="O6" type="1824"/>
-   <Atom name="N1" type="1825"/>
-   <Atom name="C2" type="1827"/>
-   <Atom name="N2" type="1828"/>
-   <Atom name="N3" type="1830"/>
-   <Atom name="C4" type="1831"/>
-   <Atom name="C3'" type="1832"/>
-   <Atom name="C2'" type="1834"/>
-   <Atom name="O2'" type="1836"/>
-   <Atom name="O3'" type="1838"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="16"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="17"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="15"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="15"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="19"/>
-   <Bond from="17" to="18"/>
-  </Residue>
-  <Residue name="CGLU">
-   <Atom name="N" type="456"/>
-   <Atom name="CA" type="458"/>
-   <Atom name="CB" type="460"/>
-   <Atom name="CG" type="462"/>
-   <Atom name="CD" type="464"/>
-   <Atom name="OE1" type="465"/>
-   <Atom name="OE2" type="466"/>
-   <Atom name="C" type="467"/>
-   <Atom name="O" type="468"/>
-   <Atom name="OXT" type="469"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="9"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="CGLY">
-   <Atom name="N" type="470"/>
-   <Atom name="CA" type="472"/>
-   <Atom name="C" type="474"/>
-   <Atom name="O" type="475"/>
-   <Atom name="OXT" type="476"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="CGLN">
-   <Atom name="N" type="441"/>
-   <Atom name="CA" type="443"/>
-   <Atom name="CB" type="445"/>
-   <Atom name="CG" type="447"/>
-   <Atom name="CD" type="449"/>
-   <Atom name="OE1" type="450"/>
-   <Atom name="NE2" type="451"/>
-   <Atom name="C" type="453"/>
-   <Atom name="O" type="454"/>
-   <Atom name="OXT" type="455"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="9"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NARG">
-   <Atom name="N" type="722"/>
-   <Atom name="CA" type="724"/>
-   <Atom name="CB" type="726"/>
-   <Atom name="CG" type="728"/>
-   <Atom name="CD" type="730"/>
-   <Atom name="NE" type="732"/>
-   <Atom name="CZ" type="734"/>
-   <Atom name="NH1" type="735"/>
-   <Atom name="NH2" type="737"/>
-   <Atom name="C" type="739"/>
-   <Atom name="O" type="740"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <Bond from="9" to="10"/>
-   <ExternalBond from="9"/>
-  </Residue>
-  <Residue name="RU5">
-   <Atom name="O5'" type="1900"/>
-   <Atom name="C5'" type="1901"/>
-   <Atom name="C4'" type="1903"/>
-   <Atom name="O4'" type="1905"/>
-   <Atom name="C1'" type="1906"/>
-   <Atom name="N1" type="1908"/>
-   <Atom name="C6" type="1909"/>
-   <Atom name="C5" type="1911"/>
-   <Atom name="C4" type="1913"/>
-   <Atom name="O4" type="1914"/>
-   <Atom name="N3" type="1915"/>
-   <Atom name="C2" type="1917"/>
-   <Atom name="O2" type="1918"/>
-   <Atom name="C3'" type="1919"/>
-   <Atom name="C2'" type="1921"/>
-   <Atom name="O2'" type="1923"/>
-   <Atom name="O3'" type="1925"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="13"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="14"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="11"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="13" to="14"/>
-   <Bond from="13" to="16"/>
-   <Bond from="14" to="15"/>
-   <ExternalBond from="16"/>
-  </Residue>
-  <Residue name="NTYR">
-   <Atom name="N" type="998"/>
-   <Atom name="CA" type="1000"/>
-   <Atom name="CB" type="1002"/>
-   <Atom name="CG" type="1004"/>
-   <Atom name="CD1" type="1005"/>
-   <Atom name="CE1" type="1007"/>
-   <Atom name="CZ" type="1009"/>
-   <Atom name="OH" type="1010"/>
-   <Atom name="CE2" type="1012"/>
-   <Atom name="CD2" type="1014"/>
-   <Atom name="C" type="1016"/>
-   <Atom name="O" type="1017"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="10"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="9"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="10" to="11"/>
-   <ExternalBond from="10"/>
-  </Residue>
-  <Residue name="CPRO">
-   <Atom name="N" type="610"/>
-   <Atom name="CD" type="611"/>
-   <Atom name="CG" type="613"/>
-   <Atom name="CB" type="615"/>
-   <Atom name="CA" type="617"/>
-   <Atom name="C" type="619"/>
-   <Atom name="O" type="620"/>
-   <Atom name="OXT" type="621"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="4"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="7"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="Cs+">
-   <Atom name="Cs+" type="1955"/>
-  </Residue>
-  <Residue name="TRP">
-   <Atom name="N" type="311"/>
-   <Atom name="CA" type="313"/>
-   <Atom name="CB" type="315"/>
-   <Atom name="CG" type="317"/>
-   <Atom name="CD1" type="318"/>
-   <Atom name="NE1" type="320"/>
-   <Atom name="CE2" type="322"/>
-   <Atom name="CZ2" type="323"/>
-   <Atom name="CH2" type="325"/>
-   <Atom name="CZ3" type="327"/>
-   <Atom name="CE3" type="329"/>
-   <Atom name="CD2" type="331"/>
-   <Atom name="C" type="332"/>
-   <Atom name="O" type="333"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="12"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="11"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="11"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="12" to="13"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="12"/>
-  </Residue>
-  <Residue name="NSER">
-   <Atom name="N" type="953"/>
-   <Atom name="CA" type="955"/>
-   <Atom name="CB" type="957"/>
-   <Atom name="OG" type="959"/>
-   <Atom name="C" type="961"/>
-   <Atom name="O" type="962"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="4"/>
-   <Bond from="2" to="3"/>
-   <Bond from="4" to="5"/>
-   <ExternalBond from="4"/>
-  </Residue>
-  <Residue name="NASP">
-   <Atom name="N" type="753"/>
-   <Atom name="CA" type="755"/>
-   <Atom name="CB" type="757"/>
-   <Atom name="CG" type="759"/>
-   <Atom name="OD1" type="760"/>
-   <Atom name="OD2" type="761"/>
-   <Atom name="C" type="762"/>
-   <Atom name="O" type="763"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="6"/>
   </Residue>
   <Residue name="RG3">
    <Atom name="P" type="1746"/>
@@ -2596,174 +3716,94 @@
    <Bond from="17" to="18"/>
    <ExternalBond from="19"/>
   </Residue>
-  <Residue name="NPHE">
-   <Atom name="N" type="922"/>
-   <Atom name="CA" type="924"/>
-   <Atom name="CB" type="926"/>
-   <Atom name="CG" type="928"/>
-   <Atom name="CD1" type="929"/>
-   <Atom name="CE1" type="931"/>
-   <Atom name="CZ" type="933"/>
-   <Atom name="CE2" type="935"/>
-   <Atom name="CD2" type="937"/>
-   <Atom name="C" type="939"/>
-   <Atom name="O" type="940"/>
+  <Residue name="RGN">
+   <Atom name="O5'" type="1810"/>
+   <Atom name="C5'" type="1811"/>
+   <Atom name="C4'" type="1813"/>
+   <Atom name="O4'" type="1815"/>
+   <Atom name="C1'" type="1816"/>
+   <Atom name="N9" type="1818"/>
+   <Atom name="C8" type="1819"/>
+   <Atom name="N7" type="1821"/>
+   <Atom name="C5" type="1822"/>
+   <Atom name="C6" type="1823"/>
+   <Atom name="O6" type="1824"/>
+   <Atom name="N1" type="1825"/>
+   <Atom name="C2" type="1827"/>
+   <Atom name="N2" type="1828"/>
+   <Atom name="N3" type="1830"/>
+   <Atom name="C4" type="1831"/>
+   <Atom name="C3'" type="1832"/>
+   <Atom name="C2'" type="1834"/>
+   <Atom name="O2'" type="1836"/>
+   <Atom name="O3'" type="1838"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
    <Bond from="2" to="3"/>
+   <Bond from="2" to="16"/>
    <Bond from="3" to="4"/>
-   <Bond from="3" to="8"/>
    <Bond from="4" to="5"/>
+   <Bond from="4" to="17"/>
    <Bond from="5" to="6"/>
+   <Bond from="5" to="15"/>
    <Bond from="6" to="7"/>
    <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="8" to="15"/>
    <Bond from="9" to="10"/>
-   <ExternalBond from="9"/>
+   <Bond from="9" to="11"/>
+   <Bond from="11" to="12"/>
+   <Bond from="12" to="13"/>
+   <Bond from="12" to="14"/>
+   <Bond from="14" to="15"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="19"/>
+   <Bond from="17" to="18"/>
   </Residue>
-  <Residue name="DT3">
-   <Atom name="P" type="1396"/>
-   <Atom name="O1P" type="1397"/>
-   <Atom name="O2P" type="1398"/>
-   <Atom name="O5'" type="1399"/>
-   <Atom name="C5'" type="1400"/>
-   <Atom name="C4'" type="1402"/>
-   <Atom name="O4'" type="1404"/>
-   <Atom name="C1'" type="1405"/>
-   <Atom name="N1" type="1407"/>
-   <Atom name="C6" type="1408"/>
-   <Atom name="C5" type="1410"/>
-   <Atom name="C7" type="1411"/>
-   <Atom name="C4" type="1413"/>
-   <Atom name="O4" type="1414"/>
-   <Atom name="N3" type="1415"/>
-   <Atom name="C2" type="1417"/>
-   <Atom name="O2" type="1418"/>
-   <Atom name="C3'" type="1419"/>
-   <Atom name="C2'" type="1421"/>
-   <Atom name="O3'" type="1423"/>
+  <Residue name="RU">
+   <Atom name="P" type="1840"/>
+   <Atom name="O1P" type="1841"/>
+   <Atom name="O2P" type="1842"/>
+   <Atom name="O5'" type="1843"/>
+   <Atom name="C5'" type="1844"/>
+   <Atom name="C4'" type="1846"/>
+   <Atom name="O4'" type="1848"/>
+   <Atom name="C1'" type="1849"/>
+   <Atom name="N1" type="1851"/>
+   <Atom name="C6" type="1852"/>
+   <Atom name="C5" type="1854"/>
+   <Atom name="C4" type="1856"/>
+   <Atom name="O4" type="1857"/>
+   <Atom name="N3" type="1858"/>
+   <Atom name="C2" type="1860"/>
+   <Atom name="O2" type="1861"/>
+   <Atom name="C3'" type="1862"/>
+   <Atom name="C2'" type="1864"/>
+   <Atom name="O2'" type="1866"/>
+   <Atom name="O3'" type="1868"/>
    <Bond from="0" to="1"/>
    <Bond from="0" to="2"/>
    <Bond from="0" to="3"/>
    <Bond from="3" to="4"/>
    <Bond from="4" to="5"/>
    <Bond from="5" to="6"/>
-   <Bond from="5" to="17"/>
+   <Bond from="5" to="16"/>
    <Bond from="6" to="7"/>
    <Bond from="7" to="8"/>
-   <Bond from="7" to="18"/>
+   <Bond from="7" to="17"/>
    <Bond from="8" to="9"/>
-   <Bond from="8" to="15"/>
+   <Bond from="8" to="14"/>
    <Bond from="9" to="10"/>
    <Bond from="10" to="11"/>
-   <Bond from="10" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="17" to="18"/>
-   <Bond from="17" to="19"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NASN">
-   <Atom name="N" type="741"/>
-   <Atom name="CA" type="743"/>
-   <Atom name="CB" type="745"/>
-   <Atom name="CG" type="747"/>
-   <Atom name="OD1" type="748"/>
-   <Atom name="ND2" type="749"/>
-   <Atom name="C" type="751"/>
-   <Atom name="O" type="752"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="DT5">
-   <Atom name="O5'" type="1426"/>
-   <Atom name="C5'" type="1427"/>
-   <Atom name="C4'" type="1429"/>
-   <Atom name="O4'" type="1431"/>
-   <Atom name="C1'" type="1432"/>
-   <Atom name="N1" type="1434"/>
-   <Atom name="C6" type="1435"/>
-   <Atom name="C5" type="1437"/>
-   <Atom name="C7" type="1438"/>
-   <Atom name="C4" type="1440"/>
-   <Atom name="O4" type="1441"/>
-   <Atom name="N3" type="1442"/>
-   <Atom name="C2" type="1444"/>
-   <Atom name="O2" type="1445"/>
-   <Atom name="C3'" type="1446"/>
-   <Atom name="C2'" type="1448"/>
-   <Atom name="O3'" type="1450"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="14"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="15"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="12"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="9"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
    <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
+   <Bond from="11" to="13"/>
+   <Bond from="13" to="14"/>
    <Bond from="14" to="15"/>
-   <Bond from="14" to="16"/>
-   <ExternalBond from="16"/>
-  </Residue>
-  <Residue name="ILE">
-   <Atom name="N" type="186"/>
-   <Atom name="CA" type="188"/>
-   <Atom name="CB" type="190"/>
-   <Atom name="CG2" type="192"/>
-   <Atom name="CG1" type="194"/>
-   <Atom name="CD1" type="196"/>
-   <Atom name="C" type="198"/>
-   <Atom name="O" type="199"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="6" to="7"/>
+   <Bond from="16" to="17"/>
+   <Bond from="16" to="19"/>
+   <Bond from="17" to="18"/>
    <ExternalBond from="0"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="ACE">
-   <Atom name="CH3" type="711"/>
-   <Atom name="C" type="712"/>
-   <Atom name="O" type="713"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <ExternalBond from="1"/>
-  </Residue>
-  <Residue name="K+">
-   <Atom name="K+" type="1956"/>
-  </Residue>
-  <Residue name="GLY">
-   <Atom name="N" type="131"/>
-   <Atom name="CA" type="133"/>
-   <Atom name="C" type="135"/>
-   <Atom name="O" type="136"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="2"/>
-  </Residue>
-  <Residue name="Rb+">
-   <Atom name="Rb+" type="1960"/>
+   <ExternalBond from="19"/>
   </Residue>
   <Residue name="RU3">
    <Atom name="P" type="1869"/>
@@ -2809,387 +3849,43 @@
    <Bond from="17" to="18"/>
    <ExternalBond from="0"/>
   </Residue>
-  <Residue name="GLU">
-   <Atom name="N" type="118"/>
-   <Atom name="CA" type="120"/>
-   <Atom name="CB" type="122"/>
-   <Atom name="CG" type="124"/>
-   <Atom name="CD" type="126"/>
-   <Atom name="OE1" type="127"/>
-   <Atom name="OE2" type="128"/>
-   <Atom name="C" type="129"/>
-   <Atom name="O" type="130"/>
+  <Residue name="RU5">
+   <Atom name="O5'" type="1900"/>
+   <Atom name="C5'" type="1901"/>
+   <Atom name="C4'" type="1903"/>
+   <Atom name="O4'" type="1905"/>
+   <Atom name="C1'" type="1906"/>
+   <Atom name="N1" type="1908"/>
+   <Atom name="C6" type="1909"/>
+   <Atom name="C5" type="1911"/>
+   <Atom name="C4" type="1913"/>
+   <Atom name="O4" type="1914"/>
+   <Atom name="N3" type="1915"/>
+   <Atom name="C2" type="1917"/>
+   <Atom name="O2" type="1918"/>
+   <Atom name="C3'" type="1919"/>
+   <Atom name="C2'" type="1921"/>
+   <Atom name="O2'" type="1923"/>
+   <Atom name="O3'" type="1925"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
    <Bond from="2" to="3"/>
+   <Bond from="2" to="13"/>
    <Bond from="3" to="4"/>
    <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <Bond from="7" to="8"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="7"/>
-  </Residue>
-  <Residue name="CHIS">
-   <Atom name="N" type="477"/>
-   <Atom name="CA" type="479"/>
-   <Atom name="CB" type="481"/>
-   <Atom name="CG" type="483"/>
-   <Atom name="ND1" type="484"/>
-   <Atom name="CE1" type="486"/>
-   <Atom name="NE2" type="488"/>
-   <Atom name="CD2" type="489"/>
-   <Atom name="C" type="491"/>
-   <Atom name="O" type="492"/>
-   <Atom name="OXT" type="493"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
+   <Bond from="4" to="14"/>
    <Bond from="5" to="6"/>
+   <Bond from="5" to="11"/>
    <Bond from="6" to="7"/>
+   <Bond from="7" to="8"/>
    <Bond from="8" to="9"/>
    <Bond from="8" to="10"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NALA">
-   <Atom name="N" type="714"/>
-   <Atom name="CA" type="716"/>
-   <Atom name="CB" type="718"/>
-   <Atom name="C" type="720"/>
-   <Atom name="O" type="721"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="3"/>
-   <Bond from="3" to="4"/>
-   <ExternalBond from="3"/>
-  </Residue>
-  <Residue name="ASP">
-   <Atom name="N" type="51"/>
-   <Atom name="CA" type="53"/>
-   <Atom name="CB" type="55"/>
-   <Atom name="CG" type="57"/>
-   <Atom name="OD1" type="58"/>
-   <Atom name="OD2" type="59"/>
-   <Atom name="C" type="60"/>
-   <Atom name="O" type="61"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="SER">
-   <Atom name="N" type="289"/>
-   <Atom name="CA" type="291"/>
-   <Atom name="CB" type="293"/>
-   <Atom name="OG" type="295"/>
-   <Atom name="C" type="297"/>
-   <Atom name="O" type="298"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="4"/>
-   <Bond from="2" to="3"/>
-   <Bond from="4" to="5"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="4"/>
-  </Residue>
-  <Residue name="CASN">
-   <Atom name="N" type="395"/>
-   <Atom name="CA" type="397"/>
-   <Atom name="CB" type="399"/>
-   <Atom name="CG" type="401"/>
-   <Atom name="OD1" type="402"/>
-   <Atom name="ND2" type="403"/>
-   <Atom name="C" type="405"/>
-   <Atom name="O" type="406"/>
-   <Atom name="OXT" type="407"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DGN">
-   <Atom name="O5'" type="1340"/>
-   <Atom name="C5'" type="1341"/>
-   <Atom name="C4'" type="1343"/>
-   <Atom name="O4'" type="1345"/>
-   <Atom name="C1'" type="1346"/>
-   <Atom name="N9" type="1348"/>
-   <Atom name="C8" type="1349"/>
-   <Atom name="N7" type="1351"/>
-   <Atom name="C5" type="1352"/>
-   <Atom name="C6" type="1353"/>
-   <Atom name="O6" type="1354"/>
-   <Atom name="N1" type="1355"/>
-   <Atom name="C2" type="1357"/>
-   <Atom name="N2" type="1358"/>
-   <Atom name="N3" type="1360"/>
-   <Atom name="C4" type="1361"/>
-   <Atom name="C3'" type="1362"/>
-   <Atom name="C2'" type="1364"/>
-   <Atom name="O3'" type="1366"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="16"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="17"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="15"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="15"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="18"/>
-  </Residue>
-  <Residue name="CASP">
-   <Atom name="N" type="408"/>
-   <Atom name="CA" type="410"/>
-   <Atom name="CB" type="412"/>
-   <Atom name="CG" type="414"/>
-   <Atom name="OD1" type="415"/>
-   <Atom name="OD2" type="416"/>
-   <Atom name="C" type="417"/>
-   <Atom name="O" type="418"/>
-   <Atom name="OXT" type="419"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DG">
-   <Atom name="P" type="1250"/>
-   <Atom name="O1P" type="1251"/>
-   <Atom name="O2P" type="1252"/>
-   <Atom name="O5'" type="1253"/>
-   <Atom name="C5'" type="1254"/>
-   <Atom name="C4'" type="1256"/>
-   <Atom name="O4'" type="1258"/>
-   <Atom name="C1'" type="1259"/>
-   <Atom name="N9" type="1261"/>
-   <Atom name="C8" type="1262"/>
-   <Atom name="N7" type="1264"/>
-   <Atom name="C5" type="1265"/>
-   <Atom name="C6" type="1266"/>
-   <Atom name="O6" type="1267"/>
-   <Atom name="N1" type="1268"/>
-   <Atom name="C2" type="1270"/>
-   <Atom name="N2" type="1271"/>
-   <Atom name="N3" type="1273"/>
-   <Atom name="C4" type="1274"/>
-   <Atom name="C3'" type="1275"/>
-   <Atom name="C2'" type="1277"/>
-   <Atom name="O3'" type="1279"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="19"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="20"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="18"/>
-   <Bond from="9" to="10"/>
    <Bond from="10" to="11"/>
    <Bond from="11" to="12"/>
-   <Bond from="11" to="18"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
+   <Bond from="13" to="14"/>
+   <Bond from="13" to="16"/>
    <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="15" to="17"/>
-   <Bond from="17" to="18"/>
-   <Bond from="19" to="20"/>
-   <Bond from="19" to="21"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="21"/>
-  </Residue>
-  <Residue name="ASN">
-   <Atom name="N" type="39"/>
-   <Atom name="CA" type="41"/>
-   <Atom name="CB" type="43"/>
-   <Atom name="CG" type="45"/>
-   <Atom name="OD1" type="46"/>
-   <Atom name="ND2" type="47"/>
-   <Atom name="C" type="49"/>
-   <Atom name="O" type="50"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="Cl-">
-   <Atom name="Cl-" type="1954"/>
-  </Residue>
-  <Residue name="CTHR">
-   <Atom name="N" type="633"/>
-   <Atom name="CA" type="635"/>
-   <Atom name="CB" type="637"/>
-   <Atom name="CG2" type="639"/>
-   <Atom name="OG1" type="641"/>
-   <Atom name="C" type="643"/>
-   <Atom name="O" type="644"/>
-   <Atom name="OXT" type="645"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="7"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DG3">
-   <Atom name="P" type="1280"/>
-   <Atom name="O1P" type="1281"/>
-   <Atom name="O2P" type="1282"/>
-   <Atom name="O5'" type="1283"/>
-   <Atom name="C5'" type="1284"/>
-   <Atom name="C4'" type="1286"/>
-   <Atom name="O4'" type="1288"/>
-   <Atom name="C1'" type="1289"/>
-   <Atom name="N9" type="1291"/>
-   <Atom name="C8" type="1292"/>
-   <Atom name="N7" type="1294"/>
-   <Atom name="C5" type="1295"/>
-   <Atom name="C6" type="1296"/>
-   <Atom name="O6" type="1297"/>
-   <Atom name="N1" type="1298"/>
-   <Atom name="C2" type="1300"/>
-   <Atom name="N2" type="1301"/>
-   <Atom name="N3" type="1303"/>
-   <Atom name="C4" type="1304"/>
-   <Atom name="C3'" type="1305"/>
-   <Atom name="C2'" type="1307"/>
-   <Atom name="O3'" type="1309"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="19"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="20"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="18"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="18"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="15" to="17"/>
-   <Bond from="17" to="18"/>
-   <Bond from="19" to="20"/>
-   <Bond from="19" to="21"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DG5">
-   <Atom name="O5'" type="1312"/>
-   <Atom name="C5'" type="1313"/>
-   <Atom name="C4'" type="1315"/>
-   <Atom name="O4'" type="1317"/>
-   <Atom name="C1'" type="1318"/>
-   <Atom name="N9" type="1320"/>
-   <Atom name="C8" type="1321"/>
-   <Atom name="N7" type="1323"/>
-   <Atom name="C5" type="1324"/>
-   <Atom name="C6" type="1325"/>
-   <Atom name="O6" type="1326"/>
-   <Atom name="N1" type="1327"/>
-   <Atom name="C2" type="1329"/>
-   <Atom name="N2" type="1330"/>
-   <Atom name="N3" type="1332"/>
-   <Atom name="C4" type="1333"/>
-   <Atom name="C3'" type="1334"/>
-   <Atom name="C2'" type="1336"/>
-   <Atom name="O3'" type="1338"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="16"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="17"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="15"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="15"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="18"/>
-   <ExternalBond from="18"/>
-  </Residue>
-  <Residue name="CARG">
-   <Atom name="N" type="375"/>
-   <Atom name="CA" type="377"/>
-   <Atom name="CB" type="379"/>
-   <Atom name="CG" type="381"/>
-   <Atom name="CD" type="383"/>
-   <Atom name="NE" type="385"/>
-   <Atom name="CZ" type="387"/>
-   <Atom name="NH1" type="388"/>
-   <Atom name="NH2" type="390"/>
-   <Atom name="C" type="392"/>
-   <Atom name="O" type="393"/>
-   <Atom name="OXT" type="394"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <ExternalBond from="0"/>
+   <ExternalBond from="16"/>
   </Residue>
   <Residue name="RUN">
    <Atom name="O5'" type="1927"/>
@@ -3228,415 +3924,16 @@
    <Bond from="13" to="16"/>
    <Bond from="14" to="15"/>
   </Residue>
-  <Residue name="ALA">
-   <Atom name="N" type="0"/>
-   <Atom name="CA" type="2"/>
-   <Atom name="CB" type="4"/>
-   <Atom name="C" type="6"/>
-   <Atom name="O" type="7"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="3"/>
-   <Bond from="3" to="4"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="3"/>
+  <Residue name="Rb+">
+   <Atom name="Rb+" type="1960"/>
   </Residue>
-  <Residue name="MET">
-   <Atom name="N" type="246"/>
-   <Atom name="CA" type="248"/>
-   <Atom name="CB" type="250"/>
-   <Atom name="CG" type="252"/>
-   <Atom name="SD" type="254"/>
-   <Atom name="CE" type="255"/>
-   <Atom name="C" type="257"/>
-   <Atom name="O" type="258"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="NME">
-   <Atom name="N" type="706"/>
-   <Atom name="CH3" type="708"/>
-   <Bond from="0" to="1"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="LEU">
-   <Atom name="N" type="200"/>
-   <Atom name="CA" type="202"/>
-   <Atom name="CB" type="204"/>
-   <Atom name="CG" type="206"/>
-   <Atom name="CD1" type="208"/>
-   <Atom name="CD2" type="210"/>
-   <Atom name="C" type="212"/>
-   <Atom name="O" type="213"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <Bond from="6" to="7"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="6"/>
-  </Residue>
-  <Residue name="CSER">
-   <Atom name="N" type="622"/>
-   <Atom name="CA" type="624"/>
-   <Atom name="CB" type="626"/>
-   <Atom name="OG" type="628"/>
-   <Atom name="C" type="630"/>
-   <Atom name="O" type="631"/>
-   <Atom name="OXT" type="632"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="4"/>
-   <Bond from="2" to="3"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="RC5">
-   <Atom name="O5'" type="1660"/>
-   <Atom name="C5'" type="1661"/>
-   <Atom name="C4'" type="1663"/>
-   <Atom name="O4'" type="1665"/>
-   <Atom name="C1'" type="1666"/>
-   <Atom name="N1" type="1668"/>
-   <Atom name="C6" type="1669"/>
-   <Atom name="C5" type="1671"/>
-   <Atom name="C4" type="1673"/>
-   <Atom name="N4" type="1674"/>
-   <Atom name="N3" type="1676"/>
-   <Atom name="C2" type="1677"/>
-   <Atom name="O2" type="1678"/>
-   <Atom name="C3'" type="1679"/>
-   <Atom name="C2'" type="1681"/>
-   <Atom name="O2'" type="1683"/>
-   <Atom name="O3'" type="1685"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="13"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="14"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="11"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="13" to="14"/>
-   <Bond from="13" to="16"/>
-   <Bond from="14" to="15"/>
-   <ExternalBond from="16"/>
-  </Residue>
-  <Residue name="CCYS">
-   <Atom name="N" type="420"/>
-   <Atom name="CA" type="422"/>
-   <Atom name="CB" type="424"/>
-   <Atom name="SG" type="426"/>
-   <Atom name="C" type="428"/>
-   <Atom name="O" type="429"/>
-   <Atom name="OXT" type="430"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="4"/>
-   <Bond from="2" to="3"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="6"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="CMET">
-   <Atom name="N" type="576"/>
-   <Atom name="CA" type="578"/>
-   <Atom name="CB" type="580"/>
-   <Atom name="CG" type="582"/>
-   <Atom name="SD" type="584"/>
-   <Atom name="CE" type="585"/>
-   <Atom name="C" type="587"/>
-   <Atom name="O" type="588"/>
-   <Atom name="OXT" type="589"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DC">
-   <Atom name="P" type="1144"/>
-   <Atom name="O1P" type="1145"/>
-   <Atom name="O2P" type="1146"/>
-   <Atom name="O5'" type="1147"/>
-   <Atom name="C5'" type="1148"/>
-   <Atom name="C4'" type="1150"/>
-   <Atom name="O4'" type="1152"/>
-   <Atom name="C1'" type="1153"/>
-   <Atom name="N1" type="1155"/>
-   <Atom name="C6" type="1156"/>
-   <Atom name="C5" type="1158"/>
-   <Atom name="C4" type="1160"/>
-   <Atom name="N4" type="1161"/>
-   <Atom name="N3" type="1163"/>
-   <Atom name="C2" type="1164"/>
-   <Atom name="O2" type="1165"/>
-   <Atom name="C3'" type="1166"/>
-   <Atom name="C2'" type="1168"/>
-   <Atom name="O3'" type="1170"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="16"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="17"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="18"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="18"/>
-  </Residue>
-  <Residue name="DA">
-   <Atom name="P" type="1030"/>
-   <Atom name="O1P" type="1031"/>
-   <Atom name="O2P" type="1032"/>
-   <Atom name="O5'" type="1033"/>
-   <Atom name="C5'" type="1034"/>
-   <Atom name="C4'" type="1036"/>
-   <Atom name="O4'" type="1038"/>
-   <Atom name="C1'" type="1039"/>
-   <Atom name="N9" type="1041"/>
-   <Atom name="C8" type="1042"/>
-   <Atom name="N7" type="1044"/>
-   <Atom name="C5" type="1045"/>
-   <Atom name="C6" type="1046"/>
-   <Atom name="N6" type="1047"/>
-   <Atom name="N1" type="1049"/>
-   <Atom name="C2" type="1050"/>
-   <Atom name="N3" type="1052"/>
-   <Atom name="C4" type="1053"/>
-   <Atom name="C3'" type="1054"/>
-   <Atom name="C2'" type="1056"/>
-   <Atom name="O3'" type="1058"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="18"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="19"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="17"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="17"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="16" to="17"/>
-   <Bond from="18" to="19"/>
-   <Bond from="18" to="20"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="20"/>
-  </Residue>
-  <Residue name="RCN">
-   <Atom name="O5'" type="1687"/>
-   <Atom name="C5'" type="1688"/>
-   <Atom name="C4'" type="1690"/>
-   <Atom name="O4'" type="1692"/>
-   <Atom name="C1'" type="1693"/>
-   <Atom name="N1" type="1695"/>
-   <Atom name="C6" type="1696"/>
-   <Atom name="C5" type="1698"/>
-   <Atom name="C4" type="1700"/>
-   <Atom name="N4" type="1701"/>
-   <Atom name="N3" type="1703"/>
-   <Atom name="C2" type="1704"/>
-   <Atom name="O2" type="1705"/>
-   <Atom name="C3'" type="1706"/>
-   <Atom name="C2'" type="1708"/>
-   <Atom name="O2'" type="1710"/>
-   <Atom name="O3'" type="1712"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="13"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="14"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="11"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="13" to="14"/>
-   <Bond from="13" to="16"/>
-   <Bond from="14" to="15"/>
-  </Residue>
-  <Residue name="DT">
-   <Atom name="P" type="1368"/>
-   <Atom name="O1P" type="1369"/>
-   <Atom name="O2P" type="1370"/>
-   <Atom name="O5'" type="1371"/>
-   <Atom name="C5'" type="1372"/>
-   <Atom name="C4'" type="1374"/>
-   <Atom name="O4'" type="1376"/>
-   <Atom name="C1'" type="1377"/>
-   <Atom name="N1" type="1379"/>
-   <Atom name="C6" type="1380"/>
-   <Atom name="C5" type="1382"/>
-   <Atom name="C7" type="1383"/>
-   <Atom name="C4" type="1385"/>
-   <Atom name="O4" type="1386"/>
-   <Atom name="N3" type="1387"/>
-   <Atom name="C2" type="1389"/>
-   <Atom name="O2" type="1390"/>
-   <Atom name="C3'" type="1391"/>
-   <Atom name="C2'" type="1393"/>
-   <Atom name="O3'" type="1395"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="17"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="18"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="15"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="10" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="17" to="18"/>
-   <Bond from="17" to="19"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="19"/>
-  </Residue>
-  <Residue name="CVAL">
-   <Atom name="N" type="691"/>
-   <Atom name="CA" type="693"/>
-   <Atom name="CB" type="695"/>
-   <Atom name="CG1" type="697"/>
-   <Atom name="CG2" type="699"/>
-   <Atom name="C" type="701"/>
-   <Atom name="O" type="702"/>
-   <Atom name="OXT" type="703"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="5"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="4"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="7"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DAN">
-   <Atom name="O5'" type="1117"/>
-   <Atom name="C5'" type="1118"/>
-   <Atom name="C4'" type="1120"/>
-   <Atom name="O4'" type="1122"/>
-   <Atom name="C1'" type="1123"/>
-   <Atom name="N9" type="1125"/>
-   <Atom name="C8" type="1126"/>
-   <Atom name="N7" type="1128"/>
-   <Atom name="C5" type="1129"/>
-   <Atom name="C6" type="1130"/>
-   <Atom name="N6" type="1131"/>
-   <Atom name="N1" type="1133"/>
-   <Atom name="C2" type="1134"/>
-   <Atom name="N3" type="1136"/>
-   <Atom name="C4" type="1137"/>
-   <Atom name="C3'" type="1138"/>
-   <Atom name="C2'" type="1140"/>
-   <Atom name="O3'" type="1142"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="15"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="16"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="14"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="15" to="16"/>
-   <Bond from="15" to="17"/>
-  </Residue>
-  <Residue name="HIS">
-   <Atom name="N" type="137"/>
-   <Atom name="CA" type="139"/>
-   <Atom name="CB" type="141"/>
-   <Atom name="CG" type="143"/>
-   <Atom name="ND1" type="144"/>
-   <Atom name="CE1" type="146"/>
-   <Atom name="NE2" type="148"/>
-   <Atom name="CD2" type="149"/>
-   <Atom name="C" type="151"/>
-   <Atom name="O" type="152"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <ExternalBond from="0"/>
-   <ExternalBond from="8"/>
-  </Residue>
-  <Residue name="CYS">
-   <Atom name="N" type="71"/>
-   <Atom name="CA" type="73"/>
-   <Atom name="CB" type="75"/>
-   <Atom name="SG" type="77"/>
-   <Atom name="C" type="79"/>
-   <Atom name="O" type="80"/>
+  <Residue name="SER">
+   <Atom name="N" type="289"/>
+   <Atom name="CA" type="291"/>
+   <Atom name="CB" type="293"/>
+   <Atom name="OG" type="295"/>
+   <Atom name="C" type="297"/>
+   <Atom name="O" type="298"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
    <Bond from="1" to="4"/>
@@ -3645,159 +3942,69 @@
    <ExternalBond from="0"/>
    <ExternalBond from="4"/>
   </Residue>
-  <Residue name="Na+">
-   <Atom name="Na+" type="1959"/>
-  </Residue>
-  <Residue name="HOH">
-   <Atom name="O" type="tip3p-O"/>
-  </Residue>
-  <Residue name="Li+">
-   <Atom name="Li+" type="1957"/>
-  </Residue>
-  <Residue name="DA5">
-   <Atom name="O5'" type="1090"/>
-   <Atom name="C5'" type="1091"/>
-   <Atom name="C4'" type="1093"/>
-   <Atom name="O4'" type="1095"/>
-   <Atom name="C1'" type="1096"/>
-   <Atom name="N9" type="1098"/>
-   <Atom name="C8" type="1099"/>
-   <Atom name="N7" type="1101"/>
-   <Atom name="C5" type="1102"/>
-   <Atom name="C6" type="1103"/>
-   <Atom name="N6" type="1104"/>
-   <Atom name="N1" type="1106"/>
-   <Atom name="C2" type="1107"/>
-   <Atom name="N3" type="1109"/>
-   <Atom name="C4" type="1110"/>
-   <Atom name="C3'" type="1111"/>
-   <Atom name="C2'" type="1113"/>
-   <Atom name="O3'" type="1115"/>
+  <Residue name="THR">
+   <Atom name="N" type="299"/>
+   <Atom name="CA" type="301"/>
+   <Atom name="CB" type="303"/>
+   <Atom name="CG2" type="305"/>
+   <Atom name="OG1" type="307"/>
+   <Atom name="C" type="309"/>
+   <Atom name="O" type="310"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
-   <Bond from="2" to="3"/>
-   <Bond from="2" to="15"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="4" to="16"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="14"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="9" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="12" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="15" to="16"/>
-   <Bond from="15" to="17"/>
-   <ExternalBond from="17"/>
-  </Residue>
-  <Residue name="CLYS">
-   <Atom name="N" type="559"/>
-   <Atom name="CA" type="561"/>
-   <Atom name="CB" type="563"/>
-   <Atom name="CG" type="565"/>
-   <Atom name="CD" type="567"/>
-   <Atom name="CE" type="569"/>
-   <Atom name="NZ" type="571"/>
-   <Atom name="C" type="573"/>
-   <Atom name="O" type="574"/>
-   <Atom name="OXT" type="575"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="7"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="9"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="DA3">
-   <Atom name="P" type="1059"/>
-   <Atom name="O1P" type="1060"/>
-   <Atom name="O2P" type="1061"/>
-   <Atom name="O5'" type="1062"/>
-   <Atom name="C5'" type="1063"/>
-   <Atom name="C4'" type="1065"/>
-   <Atom name="O4'" type="1067"/>
-   <Atom name="C1'" type="1068"/>
-   <Atom name="N9" type="1070"/>
-   <Atom name="C8" type="1071"/>
-   <Atom name="N7" type="1073"/>
-   <Atom name="C5" type="1074"/>
-   <Atom name="C6" type="1075"/>
-   <Atom name="N6" type="1076"/>
-   <Atom name="N1" type="1078"/>
-   <Atom name="C2" type="1079"/>
-   <Atom name="N3" type="1081"/>
-   <Atom name="C4" type="1082"/>
-   <Atom name="C3'" type="1083"/>
-   <Atom name="C2'" type="1085"/>
-   <Atom name="O3'" type="1087"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="18"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="19"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="17"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="17"/>
-   <Bond from="12" to="13"/>
-   <Bond from="12" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="15" to="16"/>
-   <Bond from="16" to="17"/>
-   <Bond from="18" to="19"/>
-   <Bond from="18" to="20"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="CILE">
-   <Atom name="N" type="529"/>
-   <Atom name="CA" type="531"/>
-   <Atom name="CB" type="533"/>
-   <Atom name="CG2" type="535"/>
-   <Atom name="CG1" type="537"/>
-   <Atom name="CD1" type="539"/>
-   <Atom name="C" type="541"/>
-   <Atom name="O" type="542"/>
-   <Atom name="OXT" type="543"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="6"/>
+   <Bond from="1" to="5"/>
    <Bond from="2" to="3"/>
    <Bond from="2" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
+   <Bond from="5" to="6"/>
    <ExternalBond from="0"/>
+   <ExternalBond from="5"/>
   </Residue>
-  <Residue name="CTYR">
-   <Atom name="N" type="670"/>
-   <Atom name="CA" type="672"/>
-   <Atom name="CB" type="674"/>
-   <Atom name="CG" type="676"/>
-   <Atom name="CD1" type="677"/>
-   <Atom name="CE1" type="679"/>
-   <Atom name="CZ" type="681"/>
-   <Atom name="OH" type="682"/>
-   <Atom name="CE2" type="684"/>
-   <Atom name="CD2" type="686"/>
-   <Atom name="C" type="688"/>
-   <Atom name="O" type="689"/>
-   <Atom name="OXT" type="690"/>
+  <Residue name="TRP">
+   <Atom name="N" type="311"/>
+   <Atom name="CA" type="313"/>
+   <Atom name="CB" type="315"/>
+   <Atom name="CG" type="317"/>
+   <Atom name="CD1" type="318"/>
+   <Atom name="NE1" type="320"/>
+   <Atom name="CE2" type="322"/>
+   <Atom name="CZ2" type="323"/>
+   <Atom name="CH2" type="325"/>
+   <Atom name="CZ3" type="327"/>
+   <Atom name="CE3" type="329"/>
+   <Atom name="CD2" type="331"/>
+   <Atom name="C" type="332"/>
+   <Atom name="O" type="333"/>
+   <Bond from="0" to="1"/>
+   <Bond from="1" to="2"/>
+   <Bond from="1" to="12"/>
+   <Bond from="2" to="3"/>
+   <Bond from="3" to="4"/>
+   <Bond from="3" to="11"/>
+   <Bond from="4" to="5"/>
+   <Bond from="5" to="6"/>
+   <Bond from="6" to="7"/>
+   <Bond from="6" to="11"/>
+   <Bond from="7" to="8"/>
+   <Bond from="8" to="9"/>
+   <Bond from="9" to="10"/>
+   <Bond from="10" to="11"/>
+   <Bond from="12" to="13"/>
+   <ExternalBond from="0"/>
+   <ExternalBond from="12"/>
+  </Residue>
+  <Residue name="TYR">
+   <Atom name="N" type="334"/>
+   <Atom name="CA" type="336"/>
+   <Atom name="CB" type="338"/>
+   <Atom name="CG" type="340"/>
+   <Atom name="CD1" type="341"/>
+   <Atom name="CE1" type="343"/>
+   <Atom name="CZ" type="345"/>
+   <Atom name="OH" type="346"/>
+   <Atom name="CE2" type="348"/>
+   <Atom name="CD2" type="350"/>
+   <Atom name="C" type="352"/>
+   <Atom name="O" type="353"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
    <Bond from="1" to="10"/>
@@ -3810,91 +4017,28 @@
    <Bond from="6" to="8"/>
    <Bond from="8" to="9"/>
    <Bond from="10" to="11"/>
-   <Bond from="10" to="12"/>
    <ExternalBond from="0"/>
+   <ExternalBond from="10"/>
   </Residue>
-  <Residue name="RC3">
-   <Atom name="P" type="1629"/>
-   <Atom name="O1P" type="1630"/>
-   <Atom name="O2P" type="1631"/>
-   <Atom name="O5'" type="1632"/>
-   <Atom name="C5'" type="1633"/>
-   <Atom name="C4'" type="1635"/>
-   <Atom name="O4'" type="1637"/>
-   <Atom name="C1'" type="1638"/>
-   <Atom name="N1" type="1640"/>
-   <Atom name="C6" type="1641"/>
-   <Atom name="C5" type="1643"/>
-   <Atom name="C4" type="1645"/>
-   <Atom name="N4" type="1646"/>
-   <Atom name="N3" type="1648"/>
-   <Atom name="C2" type="1649"/>
-   <Atom name="O2" type="1650"/>
-   <Atom name="C3'" type="1651"/>
-   <Atom name="C2'" type="1653"/>
-   <Atom name="O2'" type="1655"/>
-   <Atom name="O3'" type="1657"/>
-   <Bond from="0" to="1"/>
-   <Bond from="0" to="2"/>
-   <Bond from="0" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="5" to="16"/>
-   <Bond from="6" to="7"/>
-   <Bond from="7" to="8"/>
-   <Bond from="7" to="17"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="14"/>
-   <Bond from="9" to="10"/>
-   <Bond from="10" to="11"/>
-   <Bond from="11" to="12"/>
-   <Bond from="11" to="13"/>
-   <Bond from="13" to="14"/>
-   <Bond from="14" to="15"/>
-   <Bond from="16" to="17"/>
-   <Bond from="16" to="19"/>
-   <Bond from="17" to="18"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="ARG">
-   <Atom name="N" type="8"/>
-   <Atom name="CA" type="10"/>
-   <Atom name="CB" type="12"/>
-   <Atom name="CG" type="14"/>
-   <Atom name="CD" type="16"/>
-   <Atom name="NE" type="18"/>
-   <Atom name="CZ" type="20"/>
-   <Atom name="NH1" type="21"/>
-   <Atom name="NH2" type="23"/>
-   <Atom name="C" type="25"/>
-   <Atom name="O" type="26"/>
+  <Residue name="VAL">
+   <Atom name="N" type="354"/>
+   <Atom name="CA" type="356"/>
+   <Atom name="CB" type="358"/>
+   <Atom name="CG1" type="360"/>
+   <Atom name="CG2" type="362"/>
+   <Atom name="C" type="364"/>
+   <Atom name="O" type="365"/>
    <Bond from="0" to="1"/>
    <Bond from="1" to="2"/>
-   <Bond from="1" to="9"/>
+   <Bond from="1" to="5"/>
    <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="4" to="5"/>
+   <Bond from="2" to="4"/>
    <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="6" to="8"/>
-   <Bond from="9" to="10"/>
    <ExternalBond from="0"/>
-   <ExternalBond from="9"/>
+   <ExternalBond from="5"/>
   </Residue>
-  <Residue name="CALA">
-   <Atom name="N" type="366"/>
-   <Atom name="CA" type="368"/>
-   <Atom name="CB" type="370"/>
-   <Atom name="C" type="372"/>
-   <Atom name="O" type="373"/>
-   <Atom name="OXT" type="374"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="5"/>
-   <ExternalBond from="0"/>
+  <Residue name="HOH">
+   <Atom name="O" type="tip3p-O"/>
   </Residue>
  </Residues>
  <HarmonicBondForce>
@@ -4111,12 +4255,12 @@
   <Angle class1="CT" class2="CT" class3="C3" angle="1.91114" k="10"/>
  </HarmonicAngleForce>
  <PeriodicTorsionForce>
-  <Proper class1="C" class2="C6" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="C5" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="C" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="C6" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="C5" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="C" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
   <Proper class1="O2" class2="C6" class3="CT" class4="CT"  periodicity1="6" phase1="3.14159" k1="0.0554501"  periodicity2="4" phase2="3.14159" k2="0.575718"  periodicity3="2" phase3="3.14159" k3="1.85435" />
   <Proper class1="N" class2="C5" class3="CT" class4="CT"  periodicity1="6" phase1="3.14159" k1="0.443726"  periodicity2="5" phase2="0" k2="0.543083"  periodicity3="4" phase3="0" k3="0.419655"  periodicity4="3" phase4="3.14159" k4="0.148114"  periodicity5="2" phase5="3.14159" k5="0.757304"  periodicity6="1" phase6="3.14159" k6="4.37772" />
-  <Proper class1="C" class2="C5" class3="N" class4="C"  periodicity1="2" phase1="3.14159" k1="10.46" />
+  <Proper class1="" class2="C5" class3="N" class4=""  periodicity1="2" phase1="3.14159" k1="10.46" />
   <Proper class1="C" class2="CT" class3="CT" class4="C5"  periodicity1="6" phase1="3.14159" k1="0.421417"  periodicity2="5" phase2="0" k2="0.435973"  periodicity3="4" phase3="3.14159" k3="1.74556"  periodicity4="3" phase4="0" k4="0.495804"  periodicity5="2" phase5="3.14159" k5="2.49241"  periodicity6="1" phase6="0" k6="2.38781" />
   <Proper class1="N" class2="CT" class3="CT" class4="C6"  periodicity1="6" phase1="3.14159" k1="0.890094"  periodicity2="5" phase2="0" k2="0.969433"  periodicity3="4" phase3="0" k3="1.76858"  periodicity4="3" phase4="3.14159" k4="0.0284512"  periodicity5="2" phase5="3.14159" k5="4.98022"  periodicity6="1" phase6="3.14159" k6="11.0257" />
   <Proper class1="C" class2="CT" class3="CT" class4="C4"  periodicity1="3" phase1="0" k1="0.564003"  periodicity2="2" phase2="3.14159" k2="1.49913"  periodicity3="1" phase3="0" k3="2.39074" />
@@ -4143,64 +4287,64 @@
   <Proper class1="OS" class2="P" class3="OS" class4="CT"  periodicity1="3" phase1="0" k1="1.046"  periodicity2="2" phase2="0" k2="5.0208" />
   <Proper class1="OH" class2="P" class3="OS" class4="CT"  periodicity1="3" phase1="0" k1="1.046"  periodicity2="2" phase2="0" k2="5.0208" />
   <Proper class1="CT" class2="S" class3="S" class4="CT"  periodicity1="2" phase1="0" k1="14.644"  periodicity2="3" phase2="0" k2="2.5104" />
-  <Proper class1="C" class2="OS" class3="P" class4="C"  periodicity1="3" phase1="0" k1="1.046" />
-  <Proper class1="C" class2="OH" class3="P" class4="C"  periodicity1="3" phase1="0" k1="1.046" />
-  <Proper class1="C" class2="CW" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="6.276" />
-  <Proper class1="C" class2="CV" class3="NB" class4="C"  periodicity1="2" phase1="3.14159" k1="10.0416" />
-  <Proper class1="C" class2="CR" class3="NB" class4="C"  periodicity1="2" phase1="3.14159" k1="20.92" />
-  <Proper class1="C" class2="CR" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="9.7278" />
-  <Proper class1="C" class2="C*" class3="CW" class4="C"  periodicity1="2" phase1="3.14159" k1="27.3006" />
-  <Proper class1="C" class2="C*" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="C*" class3="CB" class4="C"  periodicity1="2" phase1="3.14159" k1="7.0082" />
-  <Proper class1="C" class2="CT" class3="SH" class4="C"  periodicity1="3" phase1="0" k1="1.046" />
-  <Proper class1="C" class2="CT" class3="S" class4="C"  periodicity1="3" phase1="0" k1="1.39467" />
-  <Proper class1="C" class2="CT" class3="OS" class4="C"  periodicity1="3" phase1="0" k1="1.60387" />
-  <Proper class1="C" class2="CT" class3="OH" class4="C"  periodicity1="3" phase1="0" k1="0.697333" />
-  <Proper class1="C" class2="CT" class3="N3" class4="C"  periodicity1="3" phase1="0" k1="0.650844" />
-  <Proper class1="C" class2="CT" class3="N2" class4="C"  periodicity1="3" phase1="0" k1="0" />
-  <Proper class1="C" class2="CT" class3="N*" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="CT" class3="N" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="CT" class3="CT" class4="C"  periodicity1="3" phase1="0" k1="0.650844" />
-  <Proper class1="C" class2="CQ" class3="NC" class4="C"  periodicity1="2" phase1="3.14159" k1="28.4512" />
-  <Proper class1="C" class2="CN" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="6.3806" />
-  <Proper class1="C" class2="CM" class3="OS" class4="C"  periodicity1="2" phase1="3.14159" k1="4.3932" />
-  <Proper class1="C" class2="CM" class3="N*" class4="C"  periodicity1="2" phase1="3.14159" k1="7.7404" />
-  <Proper class1="C" class2="CM" class3="CT" class4="C"  periodicity1="3" phase1="0" k1="0" />
-  <Proper class1="C" class2="CM" class3="CM" class4="C"  periodicity1="2" phase1="3.14159" k1="27.8236" />
-  <Proper class1="C" class2="CK" class3="NB" class4="C"  periodicity1="2" phase1="3.14159" k1="41.84" />
-  <Proper class1="C" class2="CK" class3="N*" class4="C"  periodicity1="2" phase1="3.14159" k1="7.1128" />
-  <Proper class1="C" class2="CC" class3="NB" class4="C"  periodicity1="2" phase1="3.14159" k1="10.0416" />
-  <Proper class1="C" class2="CC" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="5.8576" />
-  <Proper class1="C" class2="CC" class3="CW" class4="C"  periodicity1="2" phase1="3.14159" k1="22.489" />
-  <Proper class1="C" class2="CC" class3="CV" class4="C"  periodicity1="2" phase1="3.14159" k1="21.5476" />
-  <Proper class1="C" class2="CC" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="CB" class3="NC" class4="C"  periodicity1="2" phase1="3.14159" k1="17.3636" />
-  <Proper class1="C" class2="CB" class3="NB" class4="C"  periodicity1="2" phase1="3.14159" k1="10.6692" />
-  <Proper class1="C" class2="CB" class3="N*" class4="C"  periodicity1="2" phase1="3.14159" k1="6.9036" />
-  <Proper class1="C" class2="CB" class3="CN" class4="C"  periodicity1="2" phase1="3.14159" k1="12.552" />
-  <Proper class1="C" class2="CB" class3="CB" class4="C"  periodicity1="2" phase1="3.14159" k1="22.8028" />
-  <Proper class1="C" class2="CA" class3="OH" class4="C"  periodicity1="2" phase1="3.14159" k1="3.7656" />
-  <Proper class1="C" class2="CA" class3="NC" class4="C"  periodicity1="2" phase1="3.14159" k1="20.0832" />
-  <Proper class1="C" class2="CA" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="6.276" />
-  <Proper class1="C" class2="CA" class3="N2" class4="C"  periodicity1="2" phase1="3.14159" k1="10.0416" />
-  <Proper class1="C" class2="CA" class3="CT" class4="C"  periodicity1="2" phase1="0" k1="0" />
-  <Proper class1="C" class2="CA" class3="CN" class4="C"  periodicity1="2" phase1="3.14159" k1="15.167" />
-  <Proper class1="C" class2="CA" class3="CM" class4="C"  periodicity1="2" phase1="3.14159" k1="10.6692" />
-  <Proper class1="C" class2="CA" class3="CB" class4="C"  periodicity1="2" phase1="3.14159" k1="14.644" />
-  <Proper class1="C" class2="CA" class3="CA" class4="C"  periodicity1="2" phase1="3.14159" k1="15.167" />
-  <Proper class1="C" class2="C" class3="OS" class4="C"  periodicity1="2" phase1="3.14159" k1="11.2968" />
-  <Proper class1="C" class2="C" class3="OH" class4="C"  periodicity1="2" phase1="3.14159" k1="9.6232" />
-  <Proper class1="C" class2="C" class3="O" class4="C"  periodicity1="2" phase1="3.14159" k1="11.7152" />
-  <Proper class1="C" class2="C" class3="NC" class4="C"  periodicity1="2" phase1="3.14159" k1="16.736" />
-  <Proper class1="C" class2="C" class3="NA" class4="C"  periodicity1="2" phase1="3.14159" k1="5.6484" />
-  <Proper class1="C" class2="C" class3="N*" class4="C"  periodicity1="2" phase1="3.14159" k1="6.0668" />
-  <Proper class1="C" class2="C" class3="N" class4="C"  periodicity1="2" phase1="3.14159" k1="10.46" />
-  <Proper class1="C" class2="C" class3="CM" class4="C"  periodicity1="2" phase1="3.14159" k1="9.1002" />
-  <Proper class1="C" class2="C" class3="CB" class4="C"  periodicity1="2" phase1="3.14159" k1="12.552" />
-  <Proper class1="C" class2="C" class3="CA" class4="C"  periodicity1="2" phase1="3.14159" k1="15.167" />
-  <Proper class1="C" class2="C" class3="C" class4="C"  periodicity1="2" phase1="3.14159" k1="15.167" />
-  <Improper class1="C5" class2="C" class3="C" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C6" class2="C" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Proper class1="" class2="OS" class3="P" class4=""  periodicity1="3" phase1="0" k1="1.046" />
+  <Proper class1="" class2="OH" class3="P" class4=""  periodicity1="3" phase1="0" k1="1.046" />
+  <Proper class1="" class2="CW" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="6.276" />
+  <Proper class1="" class2="CV" class3="NB" class4=""  periodicity1="2" phase1="3.14159" k1="10.0416" />
+  <Proper class1="" class2="CR" class3="NB" class4=""  periodicity1="2" phase1="3.14159" k1="20.92" />
+  <Proper class1="" class2="CR" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="9.7278" />
+  <Proper class1="" class2="C*" class3="CW" class4=""  periodicity1="2" phase1="3.14159" k1="27.3006" />
+  <Proper class1="" class2="C*" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="C*" class3="CB" class4=""  periodicity1="2" phase1="3.14159" k1="7.0082" />
+  <Proper class1="" class2="CT" class3="SH" class4=""  periodicity1="3" phase1="0" k1="1.046" />
+  <Proper class1="" class2="CT" class3="S" class4=""  periodicity1="3" phase1="0" k1="1.39467" />
+  <Proper class1="" class2="CT" class3="OS" class4=""  periodicity1="3" phase1="0" k1="1.60387" />
+  <Proper class1="" class2="CT" class3="OH" class4=""  periodicity1="3" phase1="0" k1="0.697333" />
+  <Proper class1="" class2="CT" class3="N3" class4=""  periodicity1="3" phase1="0" k1="0.650844" />
+  <Proper class1="" class2="CT" class3="N2" class4=""  periodicity1="3" phase1="0" k1="0" />
+  <Proper class1="" class2="CT" class3="N*" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="CT" class3="N" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="CT" class3="CT" class4=""  periodicity1="3" phase1="0" k1="0.650844" />
+  <Proper class1="" class2="CQ" class3="NC" class4=""  periodicity1="2" phase1="3.14159" k1="28.4512" />
+  <Proper class1="" class2="CN" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="6.3806" />
+  <Proper class1="" class2="CM" class3="OS" class4=""  periodicity1="2" phase1="3.14159" k1="4.3932" />
+  <Proper class1="" class2="CM" class3="N*" class4=""  periodicity1="2" phase1="3.14159" k1="7.7404" />
+  <Proper class1="" class2="CM" class3="CT" class4=""  periodicity1="3" phase1="0" k1="0" />
+  <Proper class1="" class2="CM" class3="CM" class4=""  periodicity1="2" phase1="3.14159" k1="27.8236" />
+  <Proper class1="" class2="CK" class3="NB" class4=""  periodicity1="2" phase1="3.14159" k1="41.84" />
+  <Proper class1="" class2="CK" class3="N*" class4=""  periodicity1="2" phase1="3.14159" k1="7.1128" />
+  <Proper class1="" class2="CC" class3="NB" class4=""  periodicity1="2" phase1="3.14159" k1="10.0416" />
+  <Proper class1="" class2="CC" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="5.8576" />
+  <Proper class1="" class2="CC" class3="CW" class4=""  periodicity1="2" phase1="3.14159" k1="22.489" />
+  <Proper class1="" class2="CC" class3="CV" class4=""  periodicity1="2" phase1="3.14159" k1="21.5476" />
+  <Proper class1="" class2="CC" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="CB" class3="NC" class4=""  periodicity1="2" phase1="3.14159" k1="17.3636" />
+  <Proper class1="" class2="CB" class3="NB" class4=""  periodicity1="2" phase1="3.14159" k1="10.6692" />
+  <Proper class1="" class2="CB" class3="N*" class4=""  periodicity1="2" phase1="3.14159" k1="6.9036" />
+  <Proper class1="" class2="CB" class3="CN" class4=""  periodicity1="2" phase1="3.14159" k1="12.552" />
+  <Proper class1="" class2="CB" class3="CB" class4=""  periodicity1="2" phase1="3.14159" k1="22.8028" />
+  <Proper class1="" class2="CA" class3="OH" class4=""  periodicity1="2" phase1="3.14159" k1="3.7656" />
+  <Proper class1="" class2="CA" class3="NC" class4=""  periodicity1="2" phase1="3.14159" k1="20.0832" />
+  <Proper class1="" class2="CA" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="6.276" />
+  <Proper class1="" class2="CA" class3="N2" class4=""  periodicity1="2" phase1="3.14159" k1="10.0416" />
+  <Proper class1="" class2="CA" class3="CT" class4=""  periodicity1="2" phase1="0" k1="0" />
+  <Proper class1="" class2="CA" class3="CN" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
+  <Proper class1="" class2="CA" class3="CM" class4=""  periodicity1="2" phase1="3.14159" k1="10.6692" />
+  <Proper class1="" class2="CA" class3="CB" class4=""  periodicity1="2" phase1="3.14159" k1="14.644" />
+  <Proper class1="" class2="CA" class3="CA" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
+  <Proper class1="" class2="C" class3="OS" class4=""  periodicity1="2" phase1="3.14159" k1="11.2968" />
+  <Proper class1="" class2="C" class3="OH" class4=""  periodicity1="2" phase1="3.14159" k1="9.6232" />
+  <Proper class1="" class2="C" class3="O" class4=""  periodicity1="2" phase1="3.14159" k1="11.7152" />
+  <Proper class1="" class2="C" class3="NC" class4=""  periodicity1="2" phase1="3.14159" k1="16.736" />
+  <Proper class1="" class2="C" class3="NA" class4=""  periodicity1="2" phase1="3.14159" k1="5.6484" />
+  <Proper class1="" class2="C" class3="N*" class4=""  periodicity1="2" phase1="3.14159" k1="6.0668" />
+  <Proper class1="" class2="C" class3="N" class4=""  periodicity1="2" phase1="3.14159" k1="10.46" />
+  <Proper class1="" class2="C" class3="CM" class4=""  periodicity1="2" phase1="3.14159" k1="9.1002" />
+  <Proper class1="" class2="C" class3="CB" class4=""  periodicity1="2" phase1="3.14159" k1="12.552" />
+  <Proper class1="" class2="C" class3="CA" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
+  <Proper class1="" class2="C" class3="C" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
+  <Improper class1="C5" class2="CA" class3="CA" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C6" class2="CA" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
   <Improper class1="N" class2="C5" class3="CT" class4="O"  periodicity1="2" phase1="3.14159" k1="4.6024" />
   <Improper class1="N" class2="C" class3="CT" class4="O"  periodicity1="2" phase1="3.14159" k1="4.6024" />
   <Improper class1="CA" class2="CA" class3="CA" class4="OH"  periodicity1="2" phase1="3.14159" k1="4.6024" />
@@ -4217,10 +4361,10 @@
   <Improper class1="C" class2="CT" class3="O" class4="OH"  periodicity1="2" phase1="3.14159" k1="43.932" />
   <Improper class1="N*" class2="C" class3="CM" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
   <Improper class1="N*" class2="CB" class3="CK" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
-  <Improper class1="N" class2="C" class3="CT" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
-  <Improper class1="CA" class2="C" class3="N2" class4="N2"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C" class2="C" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C" class2="C" class3="C" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="N" class2="CA" class3="CT" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
+  <Improper class1="CA" class2="CA" class3="N2" class4="N2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C" class2="CA" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C" class2="CA" class3="CA" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
  </PeriodicTorsionForce>
  <Script>
 import openmm as mm

--- a/pdbfixer/soft.xml
+++ b/pdbfixer/soft.xml
@@ -1523,56 +1523,6 @@
    <Bond from="2" to="4"/>
    <ExternalBond from="0"/>
   </Residue>
-  <Residue name="CHID">
-   <Atom name="N" type="477"/>
-   <Atom name="CA" type="479"/>
-   <Atom name="CB" type="481"/>
-   <Atom name="CG" type="483"/>
-   <Atom name="ND1" type="484"/>
-   <Atom name="CE1" type="486"/>
-   <Atom name="NE2" type="488"/>
-   <Atom name="CD2" type="489"/>
-   <Atom name="C" type="491"/>
-   <Atom name="O" type="492"/>
-   <Atom name="OXT" type="493"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="CHIE">
-   <Atom name="N" type="494"/>
-   <Atom name="CA" type="496"/>
-   <Atom name="CB" type="498"/>
-   <Atom name="CG" type="500"/>
-   <Atom name="ND1" type="501"/>
-   <Atom name="CE1" type="502"/>
-   <Atom name="NE2" type="504"/>
-   <Atom name="CD2" type="506"/>
-   <Atom name="C" type="508"/>
-   <Atom name="O" type="509"/>
-   <Atom name="OXT" type="510"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <Bond from="8" to="10"/>
-   <ExternalBond from="0"/>
-  </Residue>
   <Residue name="CHIP">
    <Atom name="N" type="511"/>
    <Atom name="CA" type="513"/>
@@ -2876,52 +2826,6 @@
   <Residue name="NHE">
    <Atom name="N" type="704"/>
    <ExternalBond from="0"/>
-  </Residue>
-  <Residue name="NHID">
-   <Atom name="N" type="816"/>
-   <Atom name="CA" type="818"/>
-   <Atom name="CB" type="820"/>
-   <Atom name="CG" type="822"/>
-   <Atom name="ND1" type="823"/>
-   <Atom name="CE1" type="825"/>
-   <Atom name="NE2" type="827"/>
-   <Atom name="CD2" type="828"/>
-   <Atom name="C" type="830"/>
-   <Atom name="O" type="831"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <ExternalBond from="8"/>
-  </Residue>
-  <Residue name="NHIE">
-   <Atom name="N" type="832"/>
-   <Atom name="CA" type="834"/>
-   <Atom name="CB" type="836"/>
-   <Atom name="CG" type="838"/>
-   <Atom name="ND1" type="839"/>
-   <Atom name="CE1" type="840"/>
-   <Atom name="NE2" type="842"/>
-   <Atom name="CD2" type="844"/>
-   <Atom name="C" type="846"/>
-   <Atom name="O" type="847"/>
-   <Bond from="0" to="1"/>
-   <Bond from="1" to="2"/>
-   <Bond from="1" to="8"/>
-   <Bond from="2" to="3"/>
-   <Bond from="3" to="4"/>
-   <Bond from="3" to="7"/>
-   <Bond from="4" to="5"/>
-   <Bond from="5" to="6"/>
-   <Bond from="6" to="7"/>
-   <Bond from="8" to="9"/>
-   <ExternalBond from="8"/>
   </Residue>
   <Residue name="NHIP">
    <Atom name="N" type="848"/>
@@ -4343,8 +4247,8 @@
   <Proper class1="" class2="C" class3="CB" class4=""  periodicity1="2" phase1="3.14159" k1="12.552" />
   <Proper class1="" class2="C" class3="CA" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
   <Proper class1="" class2="C" class3="C" class4=""  periodicity1="2" phase1="3.14159" k1="15.167" />
-  <Improper class1="C5" class2="CA" class3="CA" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C6" class2="CA" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C5" class2="" class3="" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C6" class2="" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
   <Improper class1="N" class2="C5" class3="CT" class4="O"  periodicity1="2" phase1="3.14159" k1="4.6024" />
   <Improper class1="N" class2="C" class3="CT" class4="O"  periodicity1="2" phase1="3.14159" k1="4.6024" />
   <Improper class1="CA" class2="CA" class3="CA" class4="OH"  periodicity1="2" phase1="3.14159" k1="4.6024" />
@@ -4361,10 +4265,10 @@
   <Improper class1="C" class2="CT" class3="O" class4="OH"  periodicity1="2" phase1="3.14159" k1="43.932" />
   <Improper class1="N*" class2="C" class3="CM" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
   <Improper class1="N*" class2="CB" class3="CK" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
-  <Improper class1="N" class2="CA" class3="CT" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
-  <Improper class1="CA" class2="CA" class3="N2" class4="N2"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C" class2="CA" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
-  <Improper class1="C" class2="CA" class3="CA" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="N" class2="" class3="CT" class4="CT"  periodicity1="2" phase1="3.14159" k1="4.184" />
+  <Improper class1="CA" class2="" class3="N2" class4="N2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C" class2="" class3="O2" class4="O2"  periodicity1="2" phase1="3.14159" k1="43.932" />
+  <Improper class1="C" class2="" class3="" class4="O"  periodicity1="2" phase1="3.14159" k1="43.932" />
  </PeriodicTorsionForce>
  <Script>
 import openmm as mm


### PR DESCRIPTION
Fixes #307.

The soft-core force field used for energy minimization was created based on Amber ff99SB-ILDN.  The script to create it didn't handle wildcards correctly.  That meant the force field was missing any torsion whose definition depended on a wildcard.