### PR TITLE
CI tests against the released OpenMM

### DIFF
--- a/devtools/environment-dev.yaml
+++ b/devtools/environment-dev.yaml
@@ -1,11 +1,10 @@
 name: pdbfixer-dev
 
 channels:
-  - conda-forge/label/openmm_dev
   - conda-forge
 
 dependencies:
   - pytest
-  - openmm=8.1.1dev0
+  - openmm
   - numpy
   - pip


### PR DESCRIPTION
In #295 I had to make it run tests against a prerelease build of OpenMM.  Now that 8.2 is released, we can switch it back.