### PR TITLE
Fix exception with unknown residues

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -150,10 +150,10 @@ class CCDResidueDefinition:
 
         residueName = block.getObj('chem_comp').getValue("id")
 
-        descriptorsData = block.getObj("pdbx_chem_comp_descriptor")
-        typeCol = descriptorsData.getAttributeIndex("type")
-
         atomData = block.getObj('chem_comp_atom')
+        if atomData is None:
+            # The file doesn't contain any atoms, so report that no definition is available.
+            return None
         atomNameCol = atomData.getAttributeIndex('atom_id')
         symbolCol = atomData.getAttributeIndex('type_symbol')
         leavingCol = atomData.getAttributeIndex('pdbx_leaving_atom_flag')


### PR DESCRIPTION
Fixes #321.  The error happened in a file containing the residue ID UNL (unknown ligand).  The CCD contains an entry for it, but it's a minimal file with no atoms.  That led to an exception.