### PR TITLE
Allow selecting the Platform to use

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -150,10 +150,10 @@ class CCDResidueDefinition:
 
         residueName = block.getObj('chem_comp').getValue("id")
 
-        descriptorsData = block.getObj("pdbx_chem_comp_descriptor")
-        typeCol = descriptorsData.getAttributeIndex("type")
-
         atomData = block.getObj('chem_comp_atom')
+        if atomData is None:
+            # The file doesn't contain any atoms, so report that no definition is available.
+            return None
         atomNameCol = atomData.getAttributeIndex('atom_id')
         symbolCol = atomData.getAttributeIndex('type_symbol')
         leavingCol = atomData.getAttributeIndex('pdbx_leaving_atom_flag')


### PR DESCRIPTION
This adds an optional `platform` argument to the constructor.  Fixes #323.

There's a limitation which will require a change to OpenMM to fix.  `Modeller.addMembrane()` creates a Context internally but doesn't provide a way to choose a platform.  So you if add a membrane in PDBFixer, the platform for that part of the calculation will still be chosen automatically.