### PR TITLE
Fix a bug in assigning charges from formalCharge in the CCD when that formal charge is set to '?' instead of a number.

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -169,7 +169,7 @@ class CCDResidueDefinition:
                 symbol=row[symbolCol],
                 leaving=row[leavingCol] == 'Y',
                 coords=mm.Vec3(float(row[xCol]), float(row[yCol]), float(row[zCol]))*0.1,
-                charge=row[chargeCol],
+                charge=row[chargeCol] if row[chargeCol] != "?" else 0,
                 aromatic=row[aromaticCol] == 'Y'
             ) for row in atomData.getRowList()
         ]
@@ -1638,9 +1638,6 @@ class PDBFixer(object):
             for atom in residue.atoms():
                 element = atom.element
                 formalCharge = formalCharges.get(atom.name, 0)
-                if formalCharge == "?":
-                    # Zero the charge if they're not known.
-                    formalCharge = 0
                 typeName = 'extra_'+element.symbol+'_'+str(formalCharge)
                 if (element, formalCharge) not in atomTypes:
                     atomTypes[(element, formalCharge)] = app.ForceField._AtomType(typeName, '', 0.0, element)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -1638,6 +1638,9 @@ class PDBFixer(object):
             for atom in residue.atoms():
                 element = atom.element
                 formalCharge = formalCharges.get(atom.name, 0)
+                if formalCharge == "?":
+                    # Zero the charge if they're not known.
+                    formalCharge = 0
                 typeName = 'extra_'+element.symbol+'_'+str(formalCharge)
                 if (element, formalCharge) not in atomTypes:
                     atomTypes[(element, formalCharge)] = app.ForceField._AtomType(typeName, '', 0.0, element)


### PR DESCRIPTION
See `QQ7` as an example residue:

```
data_QQ7
# 
_chem_comp.id                                    QQ7     
_chem_comp.name                                  "cucurbit[7]uril" 
_chem_comp.type                                  NON-POLYMER 
_chem_comp.pdbx_type                             HETAIN  
_chem_comp.formula                               "C42 H42 N28 O14" 
_chem_comp.mon_nstd_parent_comp_id               ?       
_chem_comp.pdbx_synonyms                         ?       
_chem_comp.pdbx_formal_charge                    0       
_chem_comp.pdbx_initial_date                     2010-02-01 
_chem_comp.pdbx_modified_date                    2011-06-04 
_chem_comp.pdbx_ambiguous_flag                   N       
_chem_comp.pdbx_release_status                   REL     
_chem_comp.pdbx_replaced_by                      ?       
_chem_comp.pdbx_replaces                         ?       
_chem_comp.formula_weight                        1162.962 
_chem_comp.one_letter_code                       ?       
_chem_comp.three_letter_code                     QQ7     
_chem_comp.pdbx_model_coordinates_details        ?       
_chem_comp.pdbx_model_coordinates_missing_flag   N 
_chem_comp.pdbx_ideal_coordinates_details        Corina  
_chem_comp.pdbx_ideal_coordinates_missing_flag   N 
_chem_comp.pdbx_model_coordinates_db_code        3LEB    
_chem_comp.pdbx_subcomponent_list                ?       
_chem_comp.pdbx_processing_site                  RCSB    
# 
loop_
_chem_comp_atom.comp_id 
_chem_comp_atom.atom_id 
_chem_comp_atom.alt_atom_id 
_chem_comp_atom.type_symbol 
_chem_comp_atom.charge 
_chem_comp_atom.pdbx_align 
_chem_comp_atom.pdbx_aromatic_flag 
_chem_comp_atom.pdbx_leaving_atom_flag 
_chem_comp_atom.pdbx_stereo_config 
_chem_comp_atom.model_Cartn_x 
_chem_comp_atom.model_Cartn_y 
_chem_comp_atom.model_Cartn_z 
_chem_comp_atom.pdbx_model_Cartn_x_ideal 
_chem_comp_atom.pdbx_model_Cartn_y_ideal 
_chem_comp_atom.pdbx_model_Cartn_z_ideal 
_chem_comp_atom.pdbx_component_atom_id 
_chem_comp_atom.pdbx_component_comp_id 
_chem_comp_atom.pdbx_ordinal 
QQ7 N01 N1  N ? 1 N N R -23.732 15.753 6.889  -23.732 15.753 6.889  N01 QQ7 1   
QQ7 C01 C1  C ? 1 N N N -22.764 16.401 6.060  -22.764 16.401 6.060  C01 QQ7 2   
QQ7 C02 C2  C ? 1 N N N -22.520 15.400 4.895  -22.520 15.400 4.895  C02 QQ7 3   
QQ7 N02 N2  N ? 1 N N N -21.463 16.618 6.616  -21.463 16.618 6.616  N02 QQ7 4   
QQ7 N03 N3  N ? 1 N N S -23.381 14.298 5.195  -23.381 14.298 5.195  N03 QQ7 5   
QQ7 N04 N4  N ? 1 N N N -21.114 15.161 4.924  -21.114 15.161 4.924  N04 QQ7 6   
QQ7 C03 C3  C ? 1 N N N -23.674 13.229 4.283  -23.674 13.229 4.283  C03 QQ7 7   
QQ7 C04 C4  C ? 1 N N N -24.436 16.391 7.962  -24.436 16.391 7.962  C04 QQ7 8
QQ7 C05 C5  C ? 1 N N N -24.148 14.550 6.328  -24.148 14.550 6.328  C05 QQ7 9
QQ7 C06 C6  C ? 1 N N N -20.386 14.477 3.894  -20.386 14.477 3.894  C06 QQ7 10
QQ7 C07 C7  C ? 1 N N N -21.152 17.644 7.569  -21.152 17.644 7.569  C07 QQ7 11
...
```