### PR TITLE
Add legacy-cgi to replace cgi

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2

--- a/devtools/environment-dev.yaml
+++ b/devtools/environment-dev.yaml
@@ -8,3 +8,4 @@ dependencies:
   - openmm
   - numpy
   - pip
+  - legacy-cgi

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ setup(
     packages=find_packages(),
     package_data={'pdbfixer': find_package_data()},
     zip_safe=False,
-    install_requires=['numpy', 'openmm >= 8.2'],
+    install_requires=['numpy', 'openmm >= 8.2', 'legacy-cgi'],
     entry_points={'console_scripts': ['pdbfixer = pdbfixer.pdbfixer:main']})
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ setup(
     packages=find_packages(),
     package_data={'pdbfixer': find_package_data()},
     zip_safe=False,
-    install_requires=['numpy', 'openmm >= 8.2', 'legacy-cgi'],
+    install_requires=['numpy', 'openmm >= 8.2', 'legacy-cgi; python_version >= "3.13"'],
     entry_points={'console_scripts': ['pdbfixer = pdbfixer.pdbfixer:main']})
 


### PR DESCRIPTION
Adds the legacy-cgi package to replace the deprecated cgi module that is gone from Python 3.13.  Resolves #318.

Does `devtools/conda-recipe/meta.yaml` need to be updated too?  This looks old and outdated compared to the [`meta.yaml` in conda-forge/pdbfixer-feedstock](https://github.com/conda-forge/pdbfixer-feedstock/blob/main/recipe/meta.yaml) so I assume it's not being used currently?