### PR TITLE
Fix position of added OXT atom

### DIFF
--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -289,6 +289,14 @@ def _findUnoccupiedDirection(point, positions):
     direction /= unit.norm(direction)
     return direction
 
+def _findOXTPosition(atomPositions: dict[str, mm.Vec3]) -> mm.Vec3:
+    """Given CA, C, and O positions, compute the position of the OXT atom."""
+    d_ca_o = atomPositions['O'] - atomPositions['CA']
+    d_ca_c = atomPositions['C'] - atomPositions['CA']
+    d_ca_c /= unit.sqrt(unit.dot(d_ca_c, d_ca_c))
+    v = d_ca_o - d_ca_c*unit.dot(d_ca_c, d_ca_o)
+    return atomPositions['O'] - 2*v
+
 class PDBFixer(object):
     """PDBFixer implements many tools for fixing problems in PDB and PDBx/mmCIF files.
     """
@@ -710,11 +718,7 @@ class PDBFixer(object):
                     if 'OXT' in terminalsToAdd:
                         newAtom = newTopology.addAtom('OXT', oxygen, newResidue)
                         newAtoms.append(newAtom)
-                        d_ca_o = atomPositions['O']-atomPositions['CA']
-                        d_ca_c = atomPositions['C']-atomPositions['CA']
-                        d_ca_c /= unit.sqrt(unit.dot(d_ca_c, d_ca_c))
-                        v = d_ca_o - d_ca_c*unit.dot(d_ca_c, d_ca_o)
-                        newPositions.append((atomPositions['O']+2*v)*unit.nanometer)
+                        newPositions.append(_findOXTPosition(atomPositions)*unit.nanometer)
         newTopology.setUnitCellDimensions(self.topology.getUnitCellDimensions())
         newTopology.createStandardBonds()
         newTopology.createDisulfideBonds(newPositions)

--- a/pdbfixer/pdbfixer.py
+++ b/pdbfixer/pdbfixer.py
@@ -289,14 +289,6 @@ def _findUnoccupiedDirection(point, positions):
     direction /= unit.norm(direction)
     return direction
 
-def _findOXTPosition(atomPositions: dict[str, mm.Vec3]) -> mm.Vec3:
-    """Given CA, C, and O positions, compute the position of the OXT atom."""
-    d_ca_o = atomPositions['O'] - atomPositions['CA']
-    d_ca_c = atomPositions['C'] - atomPositions['CA']
-    d_ca_c /= unit.sqrt(unit.dot(d_ca_c, d_ca_c))
-    v = d_ca_o - d_ca_c*unit.dot(d_ca_c, d_ca_o)
-    return atomPositions['O'] - 2*v
-
 class PDBFixer(object):
     """PDBFixer implements many tools for fixing problems in PDB and PDBx/mmCIF files.
     """
@@ -718,7 +710,11 @@ class PDBFixer(object):
                     if 'OXT' in terminalsToAdd:
                         newAtom = newTopology.addAtom('OXT', oxygen, newResidue)
                         newAtoms.append(newAtom)
-                        newPositions.append(_findOXTPosition(atomPositions)*unit.nanometer)
+                        d_ca_o = atomPositions['O']-atomPositions['CA']
+                        d_ca_c = atomPositions['C']-atomPositions['CA']
+                        d_ca_c /= unit.sqrt(unit.dot(d_ca_c, d_ca_c))
+                        v = d_ca_o - d_ca_c*unit.dot(d_ca_c, d_ca_o)
+                        newPositions.append((atomPositions['O']-2*v)*unit.nanometer)
         newTopology.setUnitCellDimensions(self.topology.getUnitCellDimensions())
         newTopology.createStandardBonds()
         newTopology.createDisulfideBonds(newPositions)

--- a/pdbfixer/tests/test_find_positions.py
+++ b/pdbfixer/tests/test_find_positions.py
@@ -1,18 +1,26 @@
-from openmm import Vec3
-from pytest import approx
+from pathlib import Path
 
-from pdbfixer.pdbfixer import _findOXTPosition
+from openmm import app, unit
 
-ATOM_POSITIONS_ALA = {
-    "N": Vec3(-0.966, 0.493, 1.500),
-    "CA": Vec3(0.257, 0.418, 0.692),
-    "C": Vec3(-0.094, 0.017, -0.716),
-    "O": Vec3(-1.056, -0.682, -0.923),
-    "CB": Vec3(1.204, -0.620, 1.296),
-    "OXT": Vec3(0.586, 0.394, -1.639),
-}
+import pdbfixer
 
 
 def test_findOXTPosition():
-    pos_oxt = _findOXTPosition(ATOM_POSITIONS_ALA)
-    assert pos_oxt == approx(ATOM_POSITIONS_ALA["OXT"], abs=1e-3)
+    """Test that OXT is added at the correct position."""
+    fixer = pdbfixer.PDBFixer(filename=(Path(__file__).parent / "data" / "1BHL.pdb").as_posix())
+
+    # Record the original position of OXT, then delete it.
+
+    originalPos = [pos for pos, atom in zip(fixer.positions, fixer.topology.atoms()) if atom.name == "OXT"]
+    modeller = app.Modeller(fixer.topology, fixer.positions)
+    modeller.delete([atom for atom in modeller.topology.atoms() if atom.name == "OXT"])
+    fixer.topology = modeller.topology
+    fixer.positions = modeller.positions
+
+    # Have PDBFixer add it back and make sure it is sufficiently close to the original position.
+
+    fixer.missingResidues = {}
+    fixer.findMissingAtoms()
+    fixer.addMissingAtoms()
+    newPos = [pos for pos, atom in zip(fixer.positions, fixer.topology.atoms()) if atom.name == "OXT"]
+    assert unit.norm(newPos[0] - originalPos[0]) < 0.01 * unit.nanometer

--- a/pdbfixer/tests/test_find_positions.py
+++ b/pdbfixer/tests/test_find_positions.py
@@ -1,0 +1,18 @@
+from openmm import Vec3
+from pytest import approx
+
+from pdbfixer.pdbfixer import _findOXTPosition
+
+ATOM_POSITIONS_ALA = {
+    "N": Vec3(-0.966, 0.493, 1.500),
+    "CA": Vec3(0.257, 0.418, 0.692),
+    "C": Vec3(-0.094, 0.017, -0.716),
+    "O": Vec3(-1.056, -0.682, -0.923),
+    "CB": Vec3(1.204, -0.620, 1.296),
+    "OXT": Vec3(0.586, 0.394, -1.639),
+}
+
+
+def test_findOXTPosition():
+    pos_oxt = _findOXTPosition(ATOM_POSITIONS_ALA)
+    assert pos_oxt == approx(ATOM_POSITIONS_ALA["OXT"], abs=1e-3)


### PR DESCRIPTION
**Problem description:** The computation of the OXT atom position is wrong, it's flipped to the wrong side. Energy minimization often fixes the position, but not always. A good example is [4JSV](https://github.com/Aqemia/pdbfixer/blob/master/pdbfixer/tests/data/4JSV.pdb).

**Summary of changes:**

- Fixed inverted sign: `+2*v` → `-2*v`
- Added pipeline test

**Example before and after:**

```sh
pdbfixer pdbfixer/tests/data/4JSV.pdb --output=oxtfix-4JSV.pdb --add-atoms=heavy
```
<img width="640" height="536" alt="image" src="https://github.com/user-attachments/assets/3252043e-0b3f-4613-ac41-349b97b96bc8" />